### PR TITLE
feat: add x-snyk-api-resource extension to compiled path info

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -15,6 +15,9 @@ const (
 	// ExtSnykApiStability is used to annotate a top-level endpoint version spec with its API release stability level.
 	ExtSnykApiStability = "x-snyk-api-stability"
 
+	// ExtSnykApiResource is used to annotate a path in a compiled OpenAPI spec with its source resource name.
+	ExtSnykApiResource = "x-snyk-api-resource"
+
 	// ExtSnykApiVersion is used to annotate a path in a compiled OpenAPI spec with its resolved release version.
 	ExtSnykApiVersion = "x-snyk-api-version"
 )
@@ -203,6 +206,7 @@ func loadResource(specPath string, versionStr string) (*Resource, error) {
 
 	ep := &Resource{Name: name, Document: doc, Version: *version}
 	for path := range doc.T.Paths {
+		doc.T.Paths[path].ExtensionProps.Extensions[ExtSnykApiResource] = name
 		doc.T.Paths[path].ExtensionProps.Extensions[ExtSnykApiVersion] = version.String()
 	}
 	return ep, nil

--- a/testdata/output/2021-06-01/spec.json
+++ b/testdata/output/2021-06-01/spec.json
@@ -394,6 +394,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-01"
     },
     "/openapi": {

--- a/testdata/output/2021-06-01/spec.yaml
+++ b/testdata/output/2021-06-01/spec.yaml
@@ -267,6 +267,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: hello-world
     x-snyk-api-version: "2021-06-01"
   /openapi:
     get:

--- a/testdata/output/2021-06-01~beta/spec.json
+++ b/testdata/output/2021-06-01~beta/spec.json
@@ -394,6 +394,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-01"
     },
     "/openapi": {

--- a/testdata/output/2021-06-01~beta/spec.yaml
+++ b/testdata/output/2021-06-01~beta/spec.yaml
@@ -267,6 +267,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: hello-world
     x-snyk-api-version: "2021-06-01"
   /openapi:
     get:

--- a/testdata/output/2021-06-01~experimental/spec.json
+++ b/testdata/output/2021-06-01~experimental/spec.json
@@ -394,6 +394,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-01"
     },
     "/openapi": {

--- a/testdata/output/2021-06-01~experimental/spec.yaml
+++ b/testdata/output/2021-06-01~experimental/spec.yaml
@@ -267,6 +267,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: hello-world
     x-snyk-api-version: "2021-06-01"
   /openapi:
     get:

--- a/testdata/output/2021-06-04/spec.json
+++ b/testdata/output/2021-06-04/spec.json
@@ -394,6 +394,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-01"
     },
     "/openapi": {

--- a/testdata/output/2021-06-04/spec.yaml
+++ b/testdata/output/2021-06-04/spec.yaml
@@ -267,6 +267,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: hello-world
     x-snyk-api-version: "2021-06-01"
   /openapi:
     get:

--- a/testdata/output/2021-06-04~beta/spec.json
+++ b/testdata/output/2021-06-04~beta/spec.json
@@ -394,6 +394,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-01"
     },
     "/openapi": {

--- a/testdata/output/2021-06-04~beta/spec.yaml
+++ b/testdata/output/2021-06-04~beta/spec.yaml
@@ -267,6 +267,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: hello-world
     x-snyk-api-version: "2021-06-01"
   /openapi:
     get:

--- a/testdata/output/2021-06-04~experimental/spec.json
+++ b/testdata/output/2021-06-04~experimental/spec.json
@@ -456,6 +456,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-01"
     },
     "/openapi": {
@@ -687,6 +688,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "projects",
       "x-snyk-api-version": "2021-06-04~experimental"
     }
   },

--- a/testdata/output/2021-06-04~experimental/spec.yaml
+++ b/testdata/output/2021-06-04~experimental/spec.yaml
@@ -316,6 +316,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: hello-world
     x-snyk-api-version: "2021-06-01"
   /openapi:
     get:
@@ -464,6 +465,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: projects
     x-snyk-api-version: 2021-06-04~experimental
 servers:
 - description: Test API v3

--- a/testdata/output/2021-06-07/spec.json
+++ b/testdata/output/2021-06-07/spec.json
@@ -394,6 +394,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-07"
     },
     "/openapi": {

--- a/testdata/output/2021-06-07/spec.yaml
+++ b/testdata/output/2021-06-07/spec.yaml
@@ -267,6 +267,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: hello-world
     x-snyk-api-version: "2021-06-07"
   /openapi:
     get:

--- a/testdata/output/2021-06-07~beta/spec.json
+++ b/testdata/output/2021-06-07~beta/spec.json
@@ -394,6 +394,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-07"
     },
     "/openapi": {

--- a/testdata/output/2021-06-07~beta/spec.yaml
+++ b/testdata/output/2021-06-07~beta/spec.yaml
@@ -267,6 +267,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: hello-world
     x-snyk-api-version: "2021-06-07"
   /openapi:
     get:

--- a/testdata/output/2021-06-07~experimental/spec.json
+++ b/testdata/output/2021-06-07~experimental/spec.json
@@ -456,6 +456,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-07"
     },
     "/openapi": {
@@ -687,6 +688,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "projects",
       "x-snyk-api-version": "2021-06-04~experimental"
     }
   },

--- a/testdata/output/2021-06-07~experimental/spec.yaml
+++ b/testdata/output/2021-06-07~experimental/spec.yaml
@@ -316,6 +316,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: hello-world
     x-snyk-api-version: "2021-06-07"
   /openapi:
     get:
@@ -464,6 +465,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: projects
     x-snyk-api-version: 2021-06-04~experimental
 servers:
 - description: Test API v3

--- a/testdata/output/2021-06-13/spec.json
+++ b/testdata/output/2021-06-13/spec.json
@@ -394,6 +394,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-07"
     },
     "/openapi": {

--- a/testdata/output/2021-06-13/spec.yaml
+++ b/testdata/output/2021-06-13/spec.yaml
@@ -267,6 +267,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: hello-world
     x-snyk-api-version: "2021-06-07"
   /openapi:
     get:

--- a/testdata/output/2021-06-13~beta/spec.json
+++ b/testdata/output/2021-06-13~beta/spec.json
@@ -413,6 +413,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-13~beta"
     },
     "/examples/hello-world/{id}": {
@@ -489,6 +490,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-13~beta"
     },
     "/openapi": {

--- a/testdata/output/2021-06-13~beta/spec.yaml
+++ b/testdata/output/2021-06-13~beta/spec.yaml
@@ -280,6 +280,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: hello-world
     x-snyk-api-version: 2021-06-13~beta
   /examples/hello-world/{id}:
     get:
@@ -328,6 +329,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: hello-world
     x-snyk-api-version: 2021-06-13~beta
   /openapi:
     get:

--- a/testdata/output/2021-06-13~experimental/spec.json
+++ b/testdata/output/2021-06-13~experimental/spec.json
@@ -475,6 +475,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-13~beta"
     },
     "/examples/hello-world/{id}": {
@@ -551,6 +552,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-13~beta"
     },
     "/openapi": {
@@ -782,6 +784,7 @@
           }
         }
       },
+      "x-snyk-api-resource": "projects",
       "x-snyk-api-version": "2021-06-04~experimental"
     }
   },

--- a/testdata/output/2021-06-13~experimental/spec.yaml
+++ b/testdata/output/2021-06-13~experimental/spec.yaml
@@ -329,6 +329,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: hello-world
     x-snyk-api-version: 2021-06-13~beta
   /examples/hello-world/{id}:
     get:
@@ -377,6 +378,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: hello-world
     x-snyk-api-version: 2021-06-13~beta
   /openapi:
     get:
@@ -525,6 +527,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-resource: projects
     x-snyk-api-version: 2021-06-04~experimental
 servers:
 - description: Test API v3


### PR DESCRIPTION
Add additional metadata to the compiled OpenAPI output indicating which
resource a given path comes from.

This is helpful for linking the compiled output back to the source, as
well as version lifecycle analysis.