### PR TITLE
feat: add extension not found utility functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/frankban/quicktest v1.13.0
-	github.com/getkin/kin-openapi v0.76.0
+	github.com/getkin/kin-openapi v0.80.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/google/go-cmp v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.13.0 h1:yNZif1OkDfNoDfb9zZa9aXIpejNR4F23Wely0c+Qdqk=
 github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/r/VLSOOIySU=
-github.com/getkin/kin-openapi v0.76.0 h1:j77zg3Ec+k+r+GA3d8hBoXpAc6KX9TbBPrwQGBIy2sY=
-github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
+github.com/getkin/kin-openapi v0.80.0 h1:W/s5/DNnDCR8P+pYyafEWlGk4S7/AfQUWXgrRSSAzf8=
+github.com/getkin/kin-openapi v0.80.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=

--- a/resource_test.go
+++ b/resource_test.go
@@ -87,3 +87,20 @@ func TestVersionRangesProjects(t *testing.T) {
 		}
 	}
 }
+
+func TestIsExtensionNotFound(t *testing.T) {
+	c := qt.New(t)
+	eps, err := LoadResourceVersions(testdata.Path("resources/_examples/hello-world"))
+	c.Assert(err, qt.IsNil)
+	resource, err := eps.At("2021-06-04~experimental")
+	c.Assert(err, qt.IsNil)
+
+	_, err = ExtensionString(resource.ExtensionProps, ExtSnykApiVersion)
+	c.Assert(IsExtensionNotFound(err), qt.IsTrue)
+
+	_, err = ExtensionString(resource.ExtensionProps, "some-bogus-value")
+	c.Assert(IsExtensionNotFound(err), qt.IsTrue)
+
+	_, err = ExtensionString(resource.ExtensionProps, ExtSnykApiStability)
+	c.Assert(IsExtensionNotFound(err), qt.IsFalse)
+}

--- a/spec_test.go
+++ b/spec_test.go
@@ -75,10 +75,12 @@ func TestSpecs(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 		_, err = ExtensionString(spec.ExtensionProps, ExtSnykApiStability)
 		c.Assert(err, qt.ErrorMatches, `extension "x-snyk-api-stability" not found`)
+		c.Assert(IsExtensionNotFound(err), qt.IsTrue)
 		m := map[expectResourceVersion]bool{}
 		for path, pathItem := range spec.Paths {
 			pathVersionStr, err := ExtensionString(pathItem.ExtensionProps, ExtSnykApiVersion)
 			c.Assert(err, qt.IsNil)
+			c.Assert(IsExtensionNotFound(err), qt.IsFalse)
 			m[expectResourceVersion{version: pathVersionStr, path: path}] = true
 		}
 		c.Assert(m, qt.HasLen, len(t.hasVersions))


### PR DESCRIPTION
Adds 3 utility functions for downstream clients to validate when using `ExtensionString` to check compiled vervet specification documents. 

* One for the stability extension
* One for the version extension
* And a generic so that the logic doesn't have to be repeated.