### PR TITLE
chore: introduce golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,6 @@ version: 2.1
 
 defaults: &defaults
   resource_class: small
-  docker:
-    - image: cimg/go:1.16
   working_directory: ~/vervet
 
 jobs:
@@ -35,9 +33,23 @@ jobs:
           name: Run tests
           command: go test ./... -count=1
 
+  lint:
+    docker:
+      - image: golangci/golangci-lint:v1.42.1
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/vervet
+      - run:
+          command: golangci-lint run -v ./...
+
 workflows:
   version: 2
   test:
     jobs:
       - test:
           name: Test
+  lint:
+    jobs:
+      - lint:
+          name: Lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+run:
+  concurrency: 4
+  timeout: 5m
+  issues-exit-code: 1
+  tests: true
+
+linters-settings:
+  gci:
+    local-prefixes: github.com/snyk/vervet
+
+linters:
+  enable:
+    - gci
+    - gofmt

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
+
+.PHONY: all
+all: lint test build
+
 .PHONY: build
 build:
 	go build -a -o vervet ./cmd/vervet
 
-# Run go mody tidy yourself
+# Run go mod tidy yourself
 
 #----------------------------------------------------------------------------------
 # Check for updates to packages in remote OSS repositories and update go.mod AND
@@ -14,6 +18,14 @@ update-deps:
 	go get -d -u ./...
 
 # go mod download yourself if you don't need to update
+
+.PHONY: lint
+lint:
+	golangci-lint run -v ./...
+
+.PHONY: lint-docker
+lint-docker:
+	docker run --rm -v $(shell pwd):/vervet -w /vervet golangci/golangci-lint:v1.42.1 golangci-lint run -v ./...
 
 #----------------------------------------------------------------------------------
 #  Ignores the test cache and forces a full test suite execution

--- a/cmd/compiler_test.go
+++ b/cmd/compiler_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCompile(t *testing.T) {
 	c := qt.New(t)
-	dstDir := c.Mkdir()
+	dstDir := c.TempDir()
 	err := cmd.App.Run([]string{"vervet", "compile", testdata.Path("resources"), dstDir})
 	c.Assert(err, qt.IsNil)
 	tests := []struct {
@@ -48,7 +48,7 @@ func TestCompile(t *testing.T) {
 
 func TestCompileInclude(t *testing.T) {
 	c := qt.New(t)
-	dstDir := c.Mkdir()
+	dstDir := c.TempDir()
 	err := cmd.App.Run([]string{"vervet", "compile", "-I", testdata.Path("resources/include.yaml"), testdata.Path("resources"), dstDir})
 	c.Assert(err, qt.IsNil)
 
@@ -87,7 +87,7 @@ func TestCompileInclude(t *testing.T) {
 
 func TestCompileConflict(t *testing.T) {
 	c := qt.New(t)
-	dstDir := c.Mkdir()
+	dstDir := c.TempDir()
 	err := cmd.App.Run([]string{"vervet", "compile", "../testdata/conflict", dstDir})
 	c.Assert(err, qt.ErrorMatches, `failed to load spec versions: conflict: .*`)
 }

--- a/cmd/localize.go
+++ b/cmd/localize.go
@@ -14,6 +14,9 @@ func Localize(ctx *cli.Context) error {
 		return fmt.Errorf("missing spec.yaml file")
 	}
 	specFile, err := absPath(ctx.Args().Get(0))
+	if err != nil {
+		return fmt.Errorf("failed to resolve %q", ctx.Args().Get(0))
+	}
 	t, err := vervet.NewDocumentFile(specFile)
 	if err != nil {
 		return fmt.Errorf("failed to load spec from %q: %v", specFile, err)
@@ -29,7 +32,7 @@ func Localize(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to convert JSON to YAML: %w", err)
 	}
-	fmt.Printf(string(yamlBuf))
+	fmt.Println(string(yamlBuf))
 
 	err = t.Validate(ctx.Context)
 	if err != nil {

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -28,7 +28,7 @@ func Resolve(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to convert JSON to YAML: %w", err)
 	}
-	fmt.Printf(string(yamlBuf))
+	fmt.Println(string(yamlBuf))
 
 	err = specVersion.Validate(ctx.Context)
 	if err != nil {

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -38,26 +37,6 @@ func ScaffoldInit(ctx *cli.Context) error {
 		return err
 	}
 	err = sc.Init()
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func copyFile(dst, src string, force bool) error {
-	srcf, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	flags := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
-	if !force {
-		flags = flags | os.O_EXCL
-	}
-	dstf, err := os.OpenFile(dst, flags, 0666)
-	if err != nil {
-		return err
-	}
-	_, err = io.Copy(dstf, srcf)
 	if err != nil {
 		return err
 	}

--- a/cmd/scaffold_test.go
+++ b/cmd/scaffold_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestScaffold(t *testing.T) {
 	c := qt.New(t)
-	dstDir := c.Mkdir()
+	dstDir := c.TempDir()
 	cd(c, dstDir)
 	// Create an API project from a scaffold
 	err := cmd.App.Run([]string{"vervet", "scaffold", "init", testdata.Path("test-scaffold")})

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -137,12 +137,6 @@ func VersionFiles(ctx *cli.Context) error {
 	return nil
 }
 
-type specVersionKey struct {
-	API      string
-	Resource string
-	Version  vervet.Version
-}
-
 // VersionNew generates a new resource.
 func VersionNew(ctx *cli.Context) error {
 	projectDir, configFile, err := projectConfig(ctx)

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -33,7 +33,7 @@ func copyToDir(c *qt.C, srcFile, dstDir string) {
 
 func TestVersionFiles(t *testing.T) {
 	c := qt.New(t)
-	tmp := c.Mkdir()
+	tmp := c.TempDir()
 	tmpFile := filepath.Join(tmp, "out")
 	c.Run("cmd", func(c *qt.C) {
 		output, err := os.Create(tmpFile)
@@ -56,7 +56,7 @@ resources/projects/2021-06-04/spec.yaml
 
 func TestVersionList(t *testing.T) {
 	c := qt.New(t)
-	tmp := c.Mkdir()
+	tmp := c.TempDir()
 	tmpFile := filepath.Join(tmp, "out")
 	c.Run("cmd", func(c *qt.C) {
 		output, err := os.Create(tmpFile)
@@ -84,7 +84,7 @@ func TestVersionList(t *testing.T) {
 
 func TestVersionNew(t *testing.T) {
 	c := qt.New(t)
-	projectDir := c.Mkdir()
+	projectDir := c.TempDir()
 	copyToDir(c, testdata.Path(".vervet.yaml"), projectDir)
 	copyToDir(c, testdata.Path("compiled-rules.yaml"), projectDir)
 	copyToDir(c, testdata.Path("resource-rules.yaml"), projectDir)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -47,7 +47,7 @@ apis:
 		Version:    "1",
 		Generators: map[string]*config.Generator{},
 		Linters: map[string]*config.Linter{
-			"apitest-resource": &config.Linter{
+			"apitest-resource": {
 				Name:        "apitest-resource",
 				Description: "Test resource rules",
 				Spectral: &config.SpectralLinter{
@@ -57,7 +57,7 @@ apis:
 					ExtraArgs: []string{"--format", "text"},
 				},
 			},
-			"apitest-compiled": &config.Linter{
+			"apitest-compiled": {
 				Name:        "apitest-compiled",
 				Description: "Test compiled rules",
 				Spectral: &config.SpectralLinter{
@@ -69,7 +69,7 @@ apis:
 			},
 		},
 		APIs: map[string]*config.API{
-			"test": &config.API{
+			"test": {
 				Name: "test",
 				Resources: []*config.ResourceSet{{
 					Linter:   "apitest-resource",
@@ -116,7 +116,7 @@ apis:
 		Generators: map[string]*config.Generator{},
 		Linters:    map[string]*config.Linter{},
 		APIs: map[string]*config.API{
-			"test": &config.API{
+			"test": {
 				Name: "test",
 				Resources: []*config.ResourceSet{{
 					Path:     "testdata/resources",

--- a/include_headers.go
+++ b/include_headers.go
@@ -29,8 +29,7 @@ func IncludeHeaders(doc *Document) error {
 }
 
 type includeHeaders struct {
-	relPath string
-	doc     *Document
+	doc *Document
 }
 
 func (w *includeHeaders) apply() error {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -110,9 +110,7 @@ func New(ctx context.Context, proj *config.Project, options ...CompilerOption) (
 				linterOverrides[rcName] = map[string][]string{}
 				for version, linter := range versionMap {
 					var overrideRules []string
-					for _, rule := range linter.Spectral.Rules {
-						overrideRules = append(overrideRules, rule)
-					}
+					overrideRules = append(overrideRules, linter.Spectral.Rules...)
 					linterOverrides[rcName][version] = overrideRules
 				}
 			}

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -63,7 +63,7 @@ func TestCompilerSmoke(t *testing.T) {
 	c := qt.New(t)
 	setup(c)
 	ctx := context.Background()
-	outputPath := c.Mkdir()
+	outputPath := c.TempDir()
 	var configBuf bytes.Buffer
 	err := configTemplate.Execute(&configBuf, outputPath)
 	c.Assert(err, qt.IsNil)

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 
 	"github.com/ghodss/yaml"
+
 	"github.com/snyk/vervet"
 	"github.com/snyk/vervet/config"
 )

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -29,7 +29,7 @@ func TestGenerators(t *testing.T) {
 	c := qt.New(t)
 	setup(c)
 
-	generated := c.Mkdir()
+	generated := c.TempDir()
 	configBuf, err := ioutil.ReadFile(testdata.Path(".vervet.yaml"))
 	c.Assert(err, qt.IsNil)
 	configBuf = bytes.ReplaceAll(configBuf, []byte("generated/{{"), []byte(generated+"/{{"))

--- a/internal/scaffold/manifest_test.go
+++ b/internal/scaffold/manifest_test.go
@@ -41,7 +41,7 @@ var manifestTests = []struct {
 
 func TestManifestValidate(t *testing.T) {
 	c := qt.New(t)
-	fakeSrc := c.Mkdir()
+	fakeSrc := c.TempDir()
 	c.Assert(ioutil.WriteFile(filepath.Join(fakeSrc, "foo"), []byte("foo"), 0666), qt.IsNil)
 	for _, t := range manifestTests {
 		m := &Manifest{

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -147,6 +147,9 @@ func (s *Scaffold) copyItem(dstPath, srcPath string) error {
 
 func (s *Scaffold) copyDir(dstPath, srcPath string) error {
 	return filepath.WalkDir(srcPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
 		name, err := filepath.Rel(srcPath, path)
 		if err != nil {
 			return err

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestScaffold(t *testing.T) {
 	c := qt.New(t)
-	dstDir := c.Mkdir()
+	dstDir := c.TempDir()
 	s, err := scaffold.New(dstDir, testdata.Path("test-scaffold"))
 	c.Assert(err, qt.IsNil)
 	err = s.Organize()

--- a/internal/spectral/linter.go
+++ b/internal/spectral/linter.go
@@ -61,10 +61,8 @@ func New(ctx context.Context, rules []string, extraArgs []string) (*Spectral, er
 	}
 	rulesPath = rulesFile.Name()
 	go func() {
-		select {
-		case <-ctx.Done():
-			os.Remove(rulesPath)
-		}
+		<-ctx.Done()
+		os.Remove(rulesPath)
 	}()
 	return &Spectral{
 		rules:        resolvedRules,

--- a/internal/sweatercomb/linter.go
+++ b/internal/sweatercomb/linter.go
@@ -78,10 +78,8 @@ func New(ctx context.Context, image string, rules []string, extraArgs []string) 
 		return nil, fmt.Errorf("failed to marshal temp rules file: %w", err)
 	}
 	go func() {
-		select {
-		case <-ctx.Done():
-			os.RemoveAll(rulesDir)
-		}
+		<-ctx.Done()
+		os.RemoveAll(rulesDir)
 	}()
 	return &SweaterComb{
 		image:     image,

--- a/internal/sweatercomb/linter_test.go
+++ b/internal/sweatercomb/linter_test.go
@@ -38,7 +38,7 @@ extends:
 	// container paths with the current working directory in spectral's output.
 	cwd, err := os.Getwd()
 	c.Assert(err, qt.IsNil)
-	tempDir := c.Mkdir()
+	tempDir := c.TempDir()
 	tempFile, err := os.Create(tempDir + "/stdout")
 	c.Assert(err, qt.IsNil)
 	c.Patch(&os.Stdout, tempFile)

--- a/localizer_test.go
+++ b/localizer_test.go
@@ -24,7 +24,7 @@ func TestLocalize(t *testing.T) {
 	// OpenAPI DOM should be fully localized and relocatable now.
 	yamlBuf, err := vervet.ToSpecYAML(doc)
 	c.Assert(err, qt.IsNil)
-	tmpDir := c.Mkdir()
+	tmpDir := c.TempDir()
 	err = ioutil.WriteFile(tmpDir+"/spec.yaml", yamlBuf, 0644)
 	c.Assert(err, qt.IsNil)
 

--- a/merge_test.go
+++ b/merge_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/snyk/vervet"
-	. "github.com/snyk/vervet"
 	"github.com/snyk/vervet/testdata"
 )
 
@@ -20,7 +19,7 @@ func TestMergeComponents(t *testing.T) {
 		src := mustLoadFile(c, "merge_test_src.yaml")
 		dstOrig := mustLoadFile(c, "merge_test_dst.yaml")
 		dst := mustLoadFile(c, "merge_test_dst.yaml")
-		Merge(dst, src, false)
+		vervet.Merge(dst, src, false)
 
 		c.Assert(dst.Components.Schemas["Foo"], openapiCmp, dstOrig.Components.Schemas["Foo"])
 		c.Assert(dst.Components.Schemas["Bar"], openapiCmp, src.Components.Schemas["Bar"])
@@ -54,7 +53,7 @@ func TestMergeComponents(t *testing.T) {
 		src := mustLoadFile(c, "merge_test_src.yaml")
 		dstOrig := mustLoadFile(c, "merge_test_dst.yaml")
 		dst := mustLoadFile(c, "merge_test_dst.yaml")
-		Merge(dst, src, true)
+		vervet.Merge(dst, src, true)
 
 		c.Assert(dst.Components.Schemas["Foo"], openapiCmp, src.Components.Schemas["Foo"])
 		c.Assert(dst.Components.Schemas["Bar"], openapiCmp, src.Components.Schemas["Bar"])
@@ -105,7 +104,7 @@ tags:
 	c.Run("tags without replace", func(c *qt.C) {
 		src := mustLoad(c, srcYaml)
 		dst := mustLoad(c, dstYaml)
-		Merge(dst, src, false)
+		vervet.Merge(dst, src, false)
 		c.Assert(dst.Tags, qt.DeepEquals, openapi3.Tags{{
 			ExtensionProps: openapi3.ExtensionProps{Extensions: map[string]interface{}{}},
 			Name:           "bar",
@@ -123,7 +122,7 @@ tags:
 	c.Run("tags with replace", func(c *qt.C) {
 		src := mustLoad(c, srcYaml)
 		dst := mustLoad(c, dstYaml)
-		Merge(dst, src, true)
+		vervet.Merge(dst, src, true)
 		c.Assert(dst.Tags, qt.DeepEquals, openapi3.Tags{{
 			ExtensionProps: openapi3.ExtensionProps{Extensions: map[string]interface{}{}},
 			Name:           "bar",
@@ -177,7 +176,7 @@ servers:
 	c.Run("servers without replace", func(c *qt.C) {
 		src := mustLoad(c, srcYaml)
 		dst := mustLoad(c, dstYaml)
-		Merge(dst, src, false)
+		vervet.Merge(dst, src, false)
 		c.Assert(dst.Info, qt.DeepEquals, &openapi3.Info{
 			ExtensionProps: openapi3.ExtensionProps{Extensions: map[string]interface{}{}},
 			Title:          "Dst",
@@ -201,7 +200,7 @@ servers:
 	c.Run("servers with replace", func(c *qt.C) {
 		src := mustLoad(c, srcYaml)
 		dst := mustLoad(c, dstYaml)
-		Merge(dst, src, true)
+		vervet.Merge(dst, src, true)
 		c.Assert(dst.Info, qt.DeepEquals, &openapi3.Info{
 			ExtensionProps: openapi3.ExtensionProps{Extensions: map[string]interface{}{}},
 			Title:          "Src",

--- a/version.go
+++ b/version.go
@@ -183,7 +183,8 @@ func (vs VersionSlice) Resolve(q Version) (*Version, error) {
 	// Did we find a match?
 	dateCmp, stabilityCmp := vs[lower].compareDateStability(&q)
 	if dateCmp <= 0 && stabilityCmp >= 0 {
-		return &vs[lower], nil
+		v := &vs[lower]
+		return v, nil
 	}
 	return nil, ErrNoMatchingVersion
 }

--- a/version_test.go
+++ b/version_test.go
@@ -198,6 +198,17 @@ func TestVersionSlice(t *testing.T) {
 			match: "2021-01-30",
 			err:   "no matching version",
 		}},
+	}, {
+		versions: VersionSlice{
+			mustParseVersion("2021-09-06"),
+			mustParseVersion("2021-10-06"),
+		},
+		first: "2021-09-06",
+		last:  "2021-10-06",
+		matchTests: []matchTest{{
+			match:  "2021-10-12~wip",
+			result: "2021-10-06",
+		}},
 	}}
 	c := qt.New(t)
 	for _, t := range tests {


### PR DESCRIPTION
Add Makefile target and CircleCI job for running golangci-lint.

Fixed dead code, uncaught errors, and style issues flagged by linter.

Drive-by: VersionSlice.Resolve:
- Returning a copy of the matched value
- Added a test case