### PR TITLE
feat: adds interactive prompting to version new cmd

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -36,10 +35,9 @@ func ScaffoldInit(ctx *cli.Context) error {
 	err = sc.Organize()
 	if err == scaffold.ErrAlreadyInitialized {
 		// If the project files already exist, prompt the user to see if they want to overwrite them.
-		// TODO: replace using Context.Value directly with a helper func to be used in other commands.
-		vervetApp, ok := ctx.Context.Value(vervetKey).(*VervetApp)
-		if !ok {
-			return errors.New("could not retrieve vervet app from context")
+		vervetApp, err := appFromContext(ctx.Context)
+		if err != nil {
+			return err
 		}
 		prompt := vervetApp.Params.Prompt
 		overwrite, err := prompt.Confirm("Scaffold already initialized; do you want to overwrite")

--- a/cmd/scaffold_test.go
+++ b/cmd/scaffold_test.go
@@ -15,11 +15,21 @@ import (
 var vervetConfigFile = "./.vervet.yaml"
 
 type testPrompt struct {
-	ReturnVal bool
+	ReturnConfirm bool
+	ReturnSelect  string
+	ReturnEntry   string
 }
 
 func (tp *testPrompt) Confirm(label string) (bool, error) {
-	return tp.ReturnVal, nil
+	return tp.ReturnConfirm, nil
+}
+
+func (tp *testPrompt) Entry(label string) (string, error) {
+	return tp.ReturnEntry, nil
+}
+
+func (tp *testPrompt) Select(label string, items []string) (string, error) {
+	return tp.ReturnSelect, nil
 }
 
 var filemark = "bad wolf"
@@ -69,7 +79,7 @@ func TestScaffold(t *testing.T) {
 
 	// Rerunning init asks the user if they want to overwrite; if they say no
 	// the command ends...
-	prompt.ReturnVal = false
+	prompt.ReturnConfirm = false
 	err = markTestFile(vervetConfigFile)
 	c.Assert(err, qt.IsNil)
 	err = testApp.Run([]string{"vervet", "scaffold", "init", testdata.Path("test-scaffold")})
@@ -79,7 +89,7 @@ func TestScaffold(t *testing.T) {
 	c.Assert(fileMarked, qt.IsTrue)
 
 	// ...if the user selects yes, it will overwrite the project files.
-	prompt.ReturnVal = true
+	prompt.ReturnConfirm = true
 	err = testApp.Run([]string{"vervet", "scaffold", "init", testdata.Path("test-scaffold")})
 	c.Assert(err, qt.IsNil)
 	fileMarked, err = markInFile(vervetConfigFile)
@@ -87,7 +97,7 @@ func TestScaffold(t *testing.T) {
 	c.Assert(fileMarked, qt.IsFalse)
 
 	// Rerunning init with the force option overwrites the project files.
-	prompt.ReturnVal = false
+	prompt.ReturnConfirm = false
 	err = markTestFile(vervetConfigFile)
 	c.Assert(err, qt.IsNil)
 	err = testApp.Run([]string{"vervet", "scaffold", "init", "--force", testdata.Path("test-scaffold")})

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -168,8 +168,27 @@ func VersionNew(ctx *cli.Context) error {
 		return err
 	}
 	apiName, resourceName := ctx.Args().Get(0), ctx.Args().Get(1)
-	if apiName == "" || resourceName == "" {
-		return fmt.Errorf("api and resource are required")
+	v, err := appFromContext(ctx.Context)
+	if err != nil {
+		return err
+	}
+	if apiName == "" {
+		i := 0
+		apis := make([]string, len(proj.APIs))
+		for k := range proj.APIs {
+			apis[i] = k
+			i++
+		}
+		apiName, err = v.Params.Prompt.Select("API for new version?", apis)
+		if err != nil {
+			return err
+		}
+	}
+	if resourceName == "" {
+		resourceName, err = v.Params.Prompt.Entry("Resource name?")
+		if err != nil {
+			return err
+		}
 	}
 	api, ok := proj.APIs[apiName]
 	if !ok && len(proj.APIs) > 0 {


### PR DESCRIPTION
The version command currently requires API and resource to be specified at
invocation. It would be better if the command interactively prompted for those
values if they were omitted by the user.

Fixes #57