### PR TITLE
fix: optic-ci compare with correct mount paths

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -126,13 +126,8 @@ github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/X
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/xanzy/ssh-agent v0.3.1 h1:AmzO1SSWxw73zxFZPRwaMN1MohDw8UyHnmuxyceTEGo=
 github.com/xanzy/ssh-agent v0.3.1/go.mod h1:QIE4lCeL7nkC25x+yA3LBIYfwCc1TFziCtG7cBAac6w=
-golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 h1:/pEO3GD/ABYAjuakUS6xSEmmlyVS4kxBNkeA9tLJiTI=
 golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 h1:DZshvxDdVoeKIbudAdFEKi+f70l51luSy/7b76ibTY0=

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -196,7 +196,7 @@ func (c *Compiler) LintResources(ctx context.Context, apiName string) error {
 		} else {
 			err := rc.linter.Run(ctx, rc.matchedFiles...)
 			if err != nil {
-				return fmt.Errorf("lint failed (apis.%s.resources[%d])", apiName, rcIndex)
+				return fmt.Errorf("lint failed: %w (apis.%s.resources[%d])", err, apiName, rcIndex)
 			}
 		}
 	}

--- a/internal/optic/files.go
+++ b/internal/optic/files.go
@@ -1,12 +1,15 @@
 package optic
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 // fileSource defines a source of files.
 type fileSource interface {
 	// Fetch retrieves the contents of the requested logical path as a local
-	// file and returns the location where it may be found. An empty string,
-	// rather than an error, is returned if the file does not exist.
+	// file and returns the absolute path where it may be found. An empty
+	// string, rather than an error, is returned if the file does not exist.
 	Fetch(path string) (string, error)
 
 	// Close releases any resources consumed in content retrieval. Any files
@@ -31,9 +34,9 @@ func (nilSource) Close() error { return nil }
 type workingCopySource struct{}
 
 // Fetch implements fileSource.
-func (workingCopySource) Fetch(path string) (string, error) {
+func (s workingCopySource) Fetch(path string) (string, error) {
 	if _, err := os.Stat(path); err == nil {
-		return path, nil
+		return filepath.Abs(path)
 	} else if os.IsNotExist(err) {
 		return "", nil
 	} else {

--- a/internal/optic/linter_test.go
+++ b/internal/optic/linter_test.go
@@ -50,18 +50,19 @@ func TestNewLocalFile(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(runner.runs, qt.DeepEquals, [][]string{{
 		"docker", "run", "--rm",
-		"-v", cwd + ":/target",
+		"-v", cwd + ":/to",
+		"-v", cwd + "/spec.yaml:/to/spec.yaml",
 		"some-image",
 		"compare",
 		"--to",
-		"spec.yaml",
+		"/to/spec.yaml",
 	}})
 
 	// Command failed.
-	runner = &mockRunner{err: fmt.Errorf("nope")}
+	runner = &mockRunner{err: fmt.Errorf("bad wolf")}
 	l.runner = runner
 	err = l.Run(ctx, "spec.yaml")
-	c.Assert(err, qt.ErrorMatches, "nope")
+	c.Assert(err, qt.ErrorMatches, "bad wolf")
 }
 
 func TestNoSuchWorkingCopyFile(t *testing.T) {


### PR DESCRIPTION
Arrange the Docker volume mounts to correctly reference the "from" and
"to" specs such that relative $refs resolve correctly.