### PR TITLE
fix: provide optic-ci with context

### DIFF
--- a/internal/linter/optic/context.go
+++ b/internal/linter/optic/context.go
@@ -1,0 +1,42 @@
+package optic
+
+// Context provides Optic with external information needed in order to process
+// API versioning lifecycle rules. For example, lifecycle rules need to know
+// when a change is occurring, and what other versions have deprecated the
+// OpenAPI spec version being evaluated.
+type Context struct {
+	// ChangeDate is when the proposed change would occur.
+	ChangeDate string `json:"changeDate"`
+
+	// ChangeResource is the proposed change resource name.
+	ChangeResource string `json:"changeResource"`
+
+	// ChangeVersion is the proposed change version.
+	ChangeVersion Version `json:"changeVersion"`
+
+	// ResourceVersions describes other resource version releases.
+	ResourceVersions ResourceVersionReleases `json:"resourceVersions,omitempty"`
+}
+
+// Version describes an API resource version, a date and a stability.
+// Stability is assumed to be GA if not specified.
+type Version struct {
+	Date      string `json:"date"`
+	Stability string `json:"stability,omitempty"`
+}
+
+// ResourceVersionReleases describes resource version releases.
+type ResourceVersionReleases map[string]VersionStabilityReleases
+
+// VersionStabilityReleases describes version releases.
+type VersionStabilityReleases map[string]StabilityReleases
+
+// StabilityReleases describes stability releases.
+type StabilityReleases map[string]Release
+
+// Release describes a single resource-version-stability release.
+type Release struct {
+	// DeprecatedBy indicates the other release version that deprecates this
+	// release.
+	DeprecatedBy Version `json:"deprecatedBy"`
+}

--- a/version.go
+++ b/version.go
@@ -106,6 +106,8 @@ func ParseStability(s string) (Stability, error) {
 		return StabilityExperimental, nil
 	case "beta":
 		return StabilityBeta, nil
+	case "ga":
+		return StabilityGA, nil
 	default:
 		return stabilityUndefined, fmt.Errorf("invalid stability %q", s)
 	}


### PR DESCRIPTION
In order for optic-ci to evaluate versioning lifecycle rules, some
external information needs to be provided, telling optic:

* When a proposed change would occur
* The resource and version being changed
* Existing versions in the API that may deprecate the version under
  change.