### PR TITLE
fix: restrict optic configuration to supported functionality

### DIFF
--- a/config/api.go
+++ b/config/api.go
@@ -105,17 +105,24 @@ func (a APIs) init(p *Project) error {
 				for version, linter := range versionMap {
 					err := linter.validate()
 					if err != nil {
-						return fmt.Errorf("%w: (apis.%s.resources[%d].linter-overrides.%s.%s)",
+						return fmt.Errorf("%w (apis.%s.resources[%d].linter-overrides.%s.%s)",
 							err, api.Name, rcIndex, rcName, version)
+					}
+					if linter.OpticCI != nil {
+						return fmt.Errorf("optic linter does not support overrides (apis.%s.resources[%d].linter-overrides.%s.%s)",
+							api.Name, rcIndex, rcName, version)
 					}
 				}
 			}
 		}
 		if api.Output != nil && api.Output.Linter != "" {
 			if api.Output.Linter != "" {
-				if _, ok := p.Linters[api.Output.Linter]; !ok {
+				if linter, ok := p.Linters[api.Output.Linter]; !ok {
 					return fmt.Errorf("linter %q not found (apis.%s.output.linter)",
 						api.Output.Linter, api.Name)
+				} else if linter.OpticCI != nil {
+					return fmt.Errorf("optic linter does not yet support compiled specs (apis.%s.output.linter)",
+						api.Name)
 				}
 			}
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -181,6 +181,47 @@ apis:
       - path: resources
         linter: foo`[1:],
 		err: `linter "foo" not found \(apis\.testapi\.resources\[0\]\.linter\)`,
+	}, {
+		conf: `
+version: "1"
+linters:
+  ci:
+    optic-ci: {}
+apis:
+  testapi:
+    resources:
+      - path: resources
+        linter: ci
+        linter-overrides:
+          foo:
+            2021-09-01:
+              optic-ci: {}
+`[1:],
+		err: `optic linter does not support overrides \(apis\.testapi\.resources\[0\]\.linter-overrides\.foo\.2021-09-01\)`,
+	}, {
+		conf: `
+version: "1"
+linters:
+  ci:
+    optic-ci: {}
+apis:
+  testapi:
+    resources:
+      - path: resources
+        linter: ci
+    output:
+      path: /somewhere/else
+      linter: ci
+`[1:],
+		err: `optic linter does not yet support compiled specs \(apis\.testapi\.output\.linter\)`,
+	}, {
+		conf: `
+linters:
+  ci:
+`[1:],
+		err: `missing linter definition \(linters\.ci\)`,
+	}, {
+		err: `no apis defined`,
 	}}
 	for i := range tests {
 		c.Logf("test#%d: %s", i, tests[i].conf)

--- a/config/linter.go
+++ b/config/linter.go
@@ -93,6 +93,9 @@ type OpticCILinter struct {
 
 func (l Linters) init() error {
 	for name, linter := range l {
+		if linter == nil {
+			return fmt.Errorf("missing linter definition (linters.%s)", name)
+		}
 		linter.Name = name
 		if err := linter.validate(); err != nil {
 			return err


### PR DESCRIPTION
Optic rules are not currently applied to the compiled output stage and
this is not yet supported, lacking a clear use case or definition.

Optic rules are also not allowed for "overrides". Linter overrides
were a stop-gap measure that should be better solved with a more
well-defined standards & compliance lifecycle.

Add some additional config sanity checks.