### PR TITLE
feat: add version deprecation and sunset eligibility

### DIFF
--- a/testdata/output/2021-06-01~experimental/spec.json
+++ b/testdata/output/2021-06-01~experimental/spec.json
@@ -400,7 +400,9 @@
         "2021-06-13~beta"
       ],
       "x-snyk-api-resource": "hello-world",
-      "x-snyk-api-version": "2021-06-01~experimental"
+      "x-snyk-api-version": "2021-06-01~experimental",
+      "x-snyk-deprecated-by": "2021-06-07~experimental",
+      "x-snyk-sunset-eligible": "2021-07-08"
     },
     "/openapi": {
       "get": {

--- a/testdata/output/2021-06-01~experimental/spec.json
+++ b/testdata/output/2021-06-01~experimental/spec.json
@@ -394,6 +394,11 @@
           }
         }
       },
+      "x-snyk-api-releases": [
+        "2021-06-01~experimental",
+        "2021-06-07~experimental",
+        "2021-06-13~beta"
+      ],
       "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-01~experimental"
     },

--- a/testdata/output/2021-06-01~experimental/spec.yaml
+++ b/testdata/output/2021-06-01~experimental/spec.yaml
@@ -267,6 +267,10 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-releases:
+    - 2021-06-01~experimental
+    - 2021-06-07~experimental
+    - 2021-06-13~beta
     x-snyk-api-resource: hello-world
     x-snyk-api-version: 2021-06-01~experimental
   /openapi:

--- a/testdata/output/2021-06-01~experimental/spec.yaml
+++ b/testdata/output/2021-06-01~experimental/spec.yaml
@@ -273,6 +273,8 @@ paths:
     - 2021-06-13~beta
     x-snyk-api-resource: hello-world
     x-snyk-api-version: 2021-06-01~experimental
+    x-snyk-deprecated-by: 2021-06-07~experimental
+    x-snyk-sunset-eligible: "2021-07-08"
   /openapi:
     get:
       description: List available versions of OpenAPI specification

--- a/testdata/output/2021-06-04~experimental/spec.json
+++ b/testdata/output/2021-06-04~experimental/spec.json
@@ -456,6 +456,11 @@
           }
         }
       },
+      "x-snyk-api-releases": [
+        "2021-06-01~experimental",
+        "2021-06-07~experimental",
+        "2021-06-13~beta"
+      ],
       "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-01~experimental"
     },
@@ -688,6 +693,9 @@
           }
         }
       },
+      "x-snyk-api-releases": [
+        "2021-06-04~experimental"
+      ],
       "x-snyk-api-resource": "projects",
       "x-snyk-api-version": "2021-06-04~experimental"
     }

--- a/testdata/output/2021-06-04~experimental/spec.json
+++ b/testdata/output/2021-06-04~experimental/spec.json
@@ -462,7 +462,9 @@
         "2021-06-13~beta"
       ],
       "x-snyk-api-resource": "hello-world",
-      "x-snyk-api-version": "2021-06-01~experimental"
+      "x-snyk-api-version": "2021-06-01~experimental",
+      "x-snyk-deprecated-by": "2021-06-07~experimental",
+      "x-snyk-sunset-eligible": "2021-07-08"
     },
     "/openapi": {
       "get": {

--- a/testdata/output/2021-06-04~experimental/spec.yaml
+++ b/testdata/output/2021-06-04~experimental/spec.yaml
@@ -316,6 +316,10 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-releases:
+    - 2021-06-01~experimental
+    - 2021-06-07~experimental
+    - 2021-06-13~beta
     x-snyk-api-resource: hello-world
     x-snyk-api-version: 2021-06-01~experimental
   /openapi:
@@ -465,6 +469,8 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-releases:
+    - 2021-06-04~experimental
     x-snyk-api-resource: projects
     x-snyk-api-version: 2021-06-04~experimental
 servers:

--- a/testdata/output/2021-06-04~experimental/spec.yaml
+++ b/testdata/output/2021-06-04~experimental/spec.yaml
@@ -322,6 +322,8 @@ paths:
     - 2021-06-13~beta
     x-snyk-api-resource: hello-world
     x-snyk-api-version: 2021-06-01~experimental
+    x-snyk-deprecated-by: 2021-06-07~experimental
+    x-snyk-sunset-eligible: "2021-07-08"
   /openapi:
     get:
       description: List available versions of OpenAPI specification

--- a/testdata/output/2021-06-07~experimental/spec.json
+++ b/testdata/output/2021-06-07~experimental/spec.json
@@ -456,6 +456,11 @@
           }
         }
       },
+      "x-snyk-api-releases": [
+        "2021-06-01~experimental",
+        "2021-06-07~experimental",
+        "2021-06-13~beta"
+      ],
       "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-07~experimental"
     },
@@ -688,6 +693,9 @@
           }
         }
       },
+      "x-snyk-api-releases": [
+        "2021-06-04~experimental"
+      ],
       "x-snyk-api-resource": "projects",
       "x-snyk-api-version": "2021-06-04~experimental"
     }

--- a/testdata/output/2021-06-07~experimental/spec.json
+++ b/testdata/output/2021-06-07~experimental/spec.json
@@ -462,7 +462,9 @@
         "2021-06-13~beta"
       ],
       "x-snyk-api-resource": "hello-world",
-      "x-snyk-api-version": "2021-06-07~experimental"
+      "x-snyk-api-version": "2021-06-07~experimental",
+      "x-snyk-deprecated-by": "2021-06-13~beta",
+      "x-snyk-sunset-eligible": "2021-07-14"
     },
     "/openapi": {
       "get": {

--- a/testdata/output/2021-06-07~experimental/spec.yaml
+++ b/testdata/output/2021-06-07~experimental/spec.yaml
@@ -322,6 +322,8 @@ paths:
     - 2021-06-13~beta
     x-snyk-api-resource: hello-world
     x-snyk-api-version: 2021-06-07~experimental
+    x-snyk-deprecated-by: 2021-06-13~beta
+    x-snyk-sunset-eligible: "2021-07-14"
   /openapi:
     get:
       description: List available versions of OpenAPI specification

--- a/testdata/output/2021-06-07~experimental/spec.yaml
+++ b/testdata/output/2021-06-07~experimental/spec.yaml
@@ -316,6 +316,10 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-releases:
+    - 2021-06-01~experimental
+    - 2021-06-07~experimental
+    - 2021-06-13~beta
     x-snyk-api-resource: hello-world
     x-snyk-api-version: 2021-06-07~experimental
   /openapi:
@@ -465,6 +469,8 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-releases:
+    - 2021-06-04~experimental
     x-snyk-api-resource: projects
     x-snyk-api-version: 2021-06-04~experimental
 servers:

--- a/testdata/output/2021-06-13~beta/spec.json
+++ b/testdata/output/2021-06-13~beta/spec.json
@@ -413,6 +413,9 @@
           }
         }
       },
+      "x-snyk-api-releases": [
+        "2021-06-13~beta"
+      ],
       "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-13~beta"
     },
@@ -490,6 +493,11 @@
           }
         }
       },
+      "x-snyk-api-releases": [
+        "2021-06-01~experimental",
+        "2021-06-07~experimental",
+        "2021-06-13~beta"
+      ],
       "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-13~beta"
     },

--- a/testdata/output/2021-06-13~beta/spec.yaml
+++ b/testdata/output/2021-06-13~beta/spec.yaml
@@ -280,6 +280,8 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-releases:
+    - 2021-06-13~beta
     x-snyk-api-resource: hello-world
     x-snyk-api-version: 2021-06-13~beta
   /examples/hello-world/{id}:
@@ -329,6 +331,10 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-releases:
+    - 2021-06-01~experimental
+    - 2021-06-07~experimental
+    - 2021-06-13~beta
     x-snyk-api-resource: hello-world
     x-snyk-api-version: 2021-06-13~beta
   /openapi:

--- a/testdata/output/2021-06-13~experimental/spec.json
+++ b/testdata/output/2021-06-13~experimental/spec.json
@@ -475,6 +475,9 @@
           }
         }
       },
+      "x-snyk-api-releases": [
+        "2021-06-13~beta"
+      ],
       "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-13~beta"
     },
@@ -552,6 +555,11 @@
           }
         }
       },
+      "x-snyk-api-releases": [
+        "2021-06-01~experimental",
+        "2021-06-07~experimental",
+        "2021-06-13~beta"
+      ],
       "x-snyk-api-resource": "hello-world",
       "x-snyk-api-version": "2021-06-13~beta"
     },
@@ -784,6 +792,9 @@
           }
         }
       },
+      "x-snyk-api-releases": [
+        "2021-06-04~experimental"
+      ],
       "x-snyk-api-resource": "projects",
       "x-snyk-api-version": "2021-06-04~experimental"
     }

--- a/testdata/output/2021-06-13~experimental/spec.yaml
+++ b/testdata/output/2021-06-13~experimental/spec.yaml
@@ -329,6 +329,8 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-releases:
+    - 2021-06-13~beta
     x-snyk-api-resource: hello-world
     x-snyk-api-version: 2021-06-13~beta
   /examples/hello-world/{id}:
@@ -378,6 +380,10 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-releases:
+    - 2021-06-01~experimental
+    - 2021-06-07~experimental
+    - 2021-06-13~beta
     x-snyk-api-resource: hello-world
     x-snyk-api-version: 2021-06-13~beta
   /openapi:
@@ -527,6 +533,8 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    x-snyk-api-releases:
+    - 2021-06-04~experimental
     x-snyk-api-resource: projects
     x-snyk-api-version: 2021-06-04~experimental
 servers:

--- a/version.go
+++ b/version.go
@@ -223,3 +223,12 @@ func (vs VersionSlice) Less(i, j int) bool {
 
 // Swap implements sort.Interface.
 func (vs VersionSlice) Swap(i, j int) { vs[i], vs[j] = vs[j], vs[i] }
+
+// Strings returns a slice of string versions
+func (vs VersionSlice) Strings() []string {
+	s := make([]string, len(vs))
+	for i := range vs {
+		s[i] = vs[i].String()
+	}
+	return s
+}


### PR DESCRIPTION
Annotate paths in a given resource version with the newer release
version that deprecates it, and when the deprecated version may be
sunset.

This may be used in linting, middleware, and documentation.

Implements #86.

Stacked on #89.