### PR TITLE
fix: ensures destination components exist in merge

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -44,7 +44,38 @@ func mergeTags(dst, src *openapi3.T, replace bool) {
 	}
 }
 
+func initDestinationComponents(dst, src *openapi3.T) {
+	if src.Components.Schemas != nil && dst.Components.Schemas == nil {
+		dst.Components.Schemas = make(map[string]*openapi3.SchemaRef)
+	}
+	if src.Components.Parameters != nil && dst.Components.Parameters == nil {
+		dst.Components.Parameters = make(map[string]*openapi3.ParameterRef)
+	}
+	if src.Components.Headers != nil && dst.Components.Headers == nil {
+		dst.Components.Headers = make(map[string]*openapi3.HeaderRef)
+	}
+	if src.Components.RequestBodies != nil && dst.Components.RequestBodies == nil {
+		dst.Components.RequestBodies = make(map[string]*openapi3.RequestBodyRef)
+	}
+	if src.Components.Responses != nil && dst.Components.Responses == nil {
+		dst.Components.Responses = make(map[string]*openapi3.ResponseRef)
+	}
+	if src.Components.SecuritySchemes != nil && dst.Components.SecuritySchemes == nil {
+		dst.Components.SecuritySchemes = make(map[string]*openapi3.SecuritySchemeRef)
+	}
+	if src.Components.Examples != nil && dst.Components.Examples == nil {
+		dst.Components.Examples = make(map[string]*openapi3.ExampleRef)
+	}
+	if src.Components.Links != nil && dst.Components.Links == nil {
+		dst.Components.Links = make(map[string]*openapi3.LinkRef)
+	}
+	if src.Components.Callbacks != nil && dst.Components.Callbacks == nil {
+		dst.Components.Callbacks = make(map[string]*openapi3.CallbackRef)
+	}
+}
+
 func mergeComponents(dst, src *openapi3.T, replace bool) {
+	initDestinationComponents(dst, src)
 	for k, v := range src.Components.Schemas {
 		if _, ok := dst.Components.Schemas[k]; !ok || replace {
 			dst.Components.Schemas[k] = v

--- a/merge_test.go
+++ b/merge_test.go
@@ -83,6 +83,40 @@ func TestMergeComponents(t *testing.T) {
 		c.Assert(dst.Components.Examples["Bar"], openapiCmp, src.Components.Examples["Bar"])
 		c.Assert(dst.Components.Examples["Baz"], openapiCmp, dstOrig.Components.Examples["Baz"])
 	})
+	c.Run("component with missing sections", func(c *qt.C) {
+		src := mustLoadFile(c, "merge_test_src.yaml")
+		dstOrig := mustLoadFile(c, "merge_test_dst_missing_components.yaml")
+		dst := mustLoadFile(c, "merge_test_dst_missing_components.yaml")
+		vervet.Merge(dst, src, true)
+
+		c.Assert(dst.Components.Schemas["Foo"], openapiCmp, src.Components.Schemas["Foo"])
+		c.Assert(dst.Components.Schemas["Bar"], openapiCmp, src.Components.Schemas["Bar"])
+		c.Assert(dst.Components.Schemas["Baz"], openapiCmp, dstOrig.Components.Schemas["Baz"])
+
+		c.Assert(dst.Components.Parameters["Foo"], openapiCmp, src.Components.Parameters["Foo"])
+		c.Assert(dst.Components.Parameters["Bar"], openapiCmp, src.Components.Parameters["Bar"])
+		c.Assert(dst.Components.Parameters["Baz"], openapiCmp, dstOrig.Components.Parameters["Baz"])
+
+		c.Assert(dst.Components.Headers["Foo"], openapiCmp, src.Components.Headers["Foo"])
+		c.Assert(dst.Components.Headers["Bar"], openapiCmp, src.Components.Headers["Bar"])
+		c.Assert(dst.Components.Headers["Baz"], openapiCmp, dstOrig.Components.Headers["Baz"])
+
+		c.Assert(dst.Components.RequestBodies["Foo"], openapiCmp, src.Components.RequestBodies["Foo"])
+		c.Assert(dst.Components.RequestBodies["Bar"], openapiCmp, src.Components.RequestBodies["Bar"])
+		c.Assert(dst.Components.RequestBodies["Baz"], openapiCmp, dstOrig.Components.RequestBodies["Baz"])
+
+		c.Assert(dst.Components.RequestBodies["200"], openapiCmp, src.Components.RequestBodies["200"])
+		c.Assert(dst.Components.RequestBodies["201"], openapiCmp, src.Components.RequestBodies["201"])
+		c.Assert(dst.Components.RequestBodies["202"], openapiCmp, dstOrig.Components.RequestBodies["202"])
+
+		c.Assert(dst.Components.SecuritySchemes["Foo"], openapiCmp, src.Components.SecuritySchemes["Foo"])
+		c.Assert(dst.Components.SecuritySchemes["Bar"], openapiCmp, src.Components.SecuritySchemes["Bar"])
+		c.Assert(dst.Components.SecuritySchemes["Baz"], openapiCmp, dstOrig.Components.SecuritySchemes["Baz"])
+
+		c.Assert(dst.Components.Examples["Foo"], openapiCmp, src.Components.Examples["Foo"])
+		c.Assert(dst.Components.Examples["Bar"], openapiCmp, src.Components.Examples["Bar"])
+		c.Assert(dst.Components.Examples["Baz"], openapiCmp, dstOrig.Components.Examples["Baz"])
+	})
 }
 
 func TestMergeTags(t *testing.T) {

--- a/testdata/merge_test_dst_missing_components.yaml
+++ b/testdata/merge_test_dst_missing_components.yaml
@@ -1,0 +1,63 @@
+components:
+  schemas:
+    Foo:
+      type: object
+      properties:
+        color:
+          type: string
+          enum: ["red", "green", "blue"]
+        dimension:
+          type: array
+          items:
+            type: number
+        strange:
+          type: boolean
+    Baz:
+      type: object
+      properties:
+        other:
+          type: boolean
+  parameters:
+    Foo:
+      in: path
+      name: foo2
+      required: true
+      schema:
+        type: string
+    Baz:
+      in: path
+      name: baz
+      required: true
+      schema:
+        type: string
+  headers:
+    Foo:
+      schema:
+        type: string
+    Baz:
+      schema:
+        type: string
+  requestBodies:
+    Foo:
+     required: true
+     content:
+       application/json:
+        schema:
+          $ref: '#/components/schemas/Foo'
+    Baz:
+     required: true
+     content:
+       application/json:
+        schema:
+          $ref: '#/components/schemas/Baz'
+  responses:
+    '200':
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: '#/components/schemas/Foo'
+    '202':
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: '#/components/schemas/Baz'


### PR DESCRIPTION
openapi3 sets the zero value of its schema objects to uninitialized
maps. This is generally fine when loading a spec, as that process
initializes the map, but when we merge items in vervet if a component
had no data in the initial spec the component map remains unitialized,
causing a panic in `Merge` when we attempt to write to it.

To address this, we check at merge time if the src component map is
initialized (not nil) and if the destination map is not. If that's the
case, we call `make` to set the map to a non nil value.