### PR TITLE
chore: optimize optic docker cmdline, add debug logging

### DIFF
--- a/config/linter.go
+++ b/config/linter.go
@@ -89,6 +89,9 @@ type OpticCILinter struct {
 	// spec file when comparing. If empty, this is assumed to be the
 	// local working copy.
 	Proposed string `json:"proposed,omitempty"`
+
+	// Debug turns on debug logging.
+	Debug bool `json:"debug,omitempty"`
 }
 
 func (l Linters) init() error {


### PR DESCRIPTION
This removes a lot of redundant volume mounts from the docker command line and adds a debug logging option to help with figuring out what vervet is actually running on `vervet lint`.