### PR TITLE
feat: add support for running optic-ci as an npm script

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -77,7 +77,7 @@ apis:
 			"ci-rules": {
 				Name: "ci-rules",
 				OpticCI: &config.OpticCILinter{
-					Image:    "ghcr.io/snyk/sweater-comb:optic-main",
+					Image:    "ghcr.io/snyk/sweater-comb:latest",
 					Original: "target-branch",
 				},
 			},

--- a/config/linter.go
+++ b/config/linter.go
@@ -4,7 +4,7 @@ import "fmt"
 
 const (
 	defaultSweaterCombImage = "gcr.io/snyk-main/sweater-comb:latest"
-	defaultOpticCIImage     = "ghcr.io/snyk/sweater-comb:optic-main"
+	defaultOpticCIImage     = "ghcr.io/snyk/sweater-comb:latest"
 )
 
 var defaultSpectralExtraArgs = []string{"--format", "text"}
@@ -81,6 +81,11 @@ type OpticCILinter struct {
 	// Image identifies the Optic CI docker image to use for linting.
 	Image string
 
+	// Script identifies the path to the Optic CI script to use for linting.
+	// Mutually exclusive with Image; if Script is specified Docker will not be
+	// used.
+	Script string
+
 	// Original is where to source the original version of an OpenAPI spec file
 	// when comparing. If empty, all changes are assumed to be new additions.
 	Original string `json:"original,omitempty"`
@@ -115,7 +120,7 @@ func (l Linters) init() error {
 			}
 		}
 		if linter.OpticCI != nil {
-			if linter.OpticCI.Image == "" {
+			if linter.OpticCI.Image == "" && linter.OpticCI.Script == "" {
 				linter.OpticCI.Image = defaultOpticCIImage
 			}
 		}


### PR DESCRIPTION
This adds the option of running optic-ci as an npm-installed script on
the host, as an alternative to a docker container. This eliminates the
overhead of having to run the tool with Docker.

Drive-by: update the docker container image