### PR TITLE
fix: empty merge destination

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -130,6 +130,9 @@ func mergeInfo(dst, src *openapi3.T, replace bool) {
 }
 
 func mergePaths(dst, src *openapi3.T, replace bool) {
+	if src.Paths != nil && dst.Paths == nil {
+		dst.Paths = make(openapi3.Paths)
+	}
 	for k, v := range src.Paths {
 		if _, ok := dst.Paths[k]; !ok || replace {
 			dst.Paths[k] = v

--- a/merge_test.go
+++ b/merge_test.go
@@ -257,6 +257,29 @@ servers:
 	})
 }
 
+func TestMergeIntoEmpty(t *testing.T) {
+	c := qt.New(t)
+	srcYaml := `
+info:
+  title: Src
+  version: src
+paths:
+  /foo:
+    get:
+    description: get a foo
+    responses:
+      200:
+      contents:
+        application/json:
+        schema:
+          type: object
+`
+	src := mustLoad(c, srcYaml)
+	dst := &openapi3.T{}
+	vervet.Merge(dst, src, false)
+	c.Assert(dst.Paths, qt.HasLen, 1)
+}
+
 func mustLoadFile(c *qt.C, path string) *openapi3.T {
 	doc, err := vervet.NewDocumentFile(testdata.Path(path))
 	c.Assert(err, qt.IsNil)


### PR DESCRIPTION
This fixes a panicking nil map deref when merging into an empty
openapi3.T destination.

This fixes an intermittent panic in VU tests I've seen in CircleCI:

```
?   	vervet-underground	[no test files]
?   	vervet-underground/config	[no test files]
{"level":"error","error":"no matching version","time":"2021-12-16T23:01:11Z","message":"Could not resolve for service http://127.0.0.1:40771 version 2021-09-01"}
{"level":"error","error":"no matching version","time":"2021-12-16T23:01:11Z","message":"Could not resolve for service http://127.0.0.1:40771 version 2021-09-16"}
--- FAIL: TestScraper (0.08s)
panic: assignment to entry in nil map [recovered]
	panic: assignment to entry in nil map

goroutine 19 [running]:
testing.tRunner.func1.2(0xb45860, 0xc774f0)
	/usr/local/go/src/testing/testing.go:1143 +0x49f
testing.tRunner.func1(0xc000182a80)
	/usr/local/go/src/testing/testing.go:1146 +0x695
panic(0xb45860, 0xc774f0)
	/usr/local/go/src/runtime/panic.go:971 +0x499
github.com/snyk/vervet.mergePaths(0xc00038d450, 0xc00038d520, 0x1)
	/go/pkg/mod/github.com/snyk/vervet@v1.3.1/merge.go:135 +0x1cb
github.com/snyk/vervet.Merge(0xc00038d450, 0xc00038d520, 0x1)
	/go/pkg/mod/github.com/snyk/vervet@v1.3.1/merge.go:20 +0xa5
vervet-underground/internal/storage/mem.(*Storage).mergeContentRevisions(0xc00018e7d0, 0x0, 0xed8fc0d00, 0x0, 0x4, 0xc000390460, 0x2, 0x2, 0x0, 0x0)
	/home/circleci/vervet/vervet-underground/internal/storage/mem/mem.go:299 +0x345
```

It's entirely possible that there is a deeper issue in VU that causes this situation to occur. However taking this trace at face value, I don't see why an empty dst should cause Merge to panic.