### PR TITLE
chore: set semantic-releaser to dry-run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           command: ./scripts/dist.bash
       - run:
           name: Release package
-          command: cd dist; npx semantic-release -b main
+          command: cd dist; npx semantic-release -b main --dry-run
 
 workflows:
   version: 2

--- a/scripts/dist.bash
+++ b/scripts/dist.bash
@@ -10,10 +10,6 @@ fi
 
 rm -rf dist
 
-NOW=$(date '+%Y%m%d%H%M')
-COMMIT=$(git rev-parse --short HEAD)
-export VERSION=$(git describe --abbrev=0)+${NOW}-${COMMIT}
-
 mkdir -p ./dist/bin
 
 for GOOS in linux darwin; do
@@ -25,4 +21,4 @@ cp packaging/npm/passthrough.js dist/bin/vervet
 cp README.md LICENSE ATTRIBUTIONS dist/
 
 go get github.com/a8m/envsubst/cmd/envsubst
-$GOPATH/bin/envsubst < packaging/npm/package.json.in > dist/package.json
+VERSION=0.0.0 $GOPATH/bin/envsubst < packaging/npm/package.json.in > dist/package.json


### PR DESCRIPTION
To avoid burning through more major versions, setting releaser to
--dry-run until we can trust it.

This way we can see what it would do in CI logs.