### PR TITLE
chore: fix working dir start point dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,8 @@ jobs:
   build-vu:
     <<: *vu_metadata
     steps:
-      - checkout
+      - checkout:
+          path: ~/vervet
       - run:
           name: build go vervet-undergound
           command: make build
@@ -81,7 +82,8 @@ jobs:
   publish-vu:
     <<: *vu_metadata
     steps:
-      - checkout
+      - checkout:
+          path: ~/vervet
       - gcr_auth
       - run:
           name: Build

--- a/vervet-underground/Dockerfile
+++ b/vervet-underground/Dockerfile
@@ -8,6 +8,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o server
 # Run
 FROM alpine:3.14
 WORKDIR /
-COPY --from=builder /src/* .
+COPY --from=builder /src/server .
 EXPOSE 8080
 CMD ["./server"]


### PR DESCRIPTION
The working directory alone does not change to the subdirectory build in CircleCI.

Fix changing working directory to use `vervet-underground` directory appropriately.