### PR TITLE
feat: per-operation versioning and deprecation

### DIFF
--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -19,7 +19,11 @@ func Resolve(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	specVersion, err := specVersions.At(ctx.String("at"))
+	version, err := vervet.ParseVersion(ctx.String("at"))
+	if err != nil {
+		return err
+	}
+	specVersion, err := specVersions.At(*version)
 	if err != nil {
 		return err
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -49,41 +49,36 @@ func VersionList(ctx *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			specVersions, err := vervet.LoadSpecVersionsFileset(specFiles)
+			resources, err := vervet.LoadResourceVersionsFileset(specFiles)
 			if err != nil {
 				return err
 			}
-			for _, rc := range specVersions.Resources() {
-				if rcArg := ctx.Args().Get(1); rcArg != "" && rcArg != rc.Name() {
-					continue
+			for _, version := range resources.Versions() {
+				rc, err := resources.At(version.String())
+				if err != nil {
+					return err
 				}
-				for _, version := range rc.Versions() {
-					doc, err := rc.At(version.String())
-					if err != nil {
-						return err
+				var pathNames []string
+				for k := range rc.Paths {
+					pathNames = append(pathNames, k)
+				}
+				sort.Strings(pathNames)
+				for _, pathName := range pathNames {
+					pathSpec := rc.Paths[pathName]
+					if pathSpec.Get != nil {
+						table.Append([]string{apiName, rc.Name, version.String(), pathName, "GET", pathSpec.Get.OperationID})
 					}
-					var pathNames []string
-					for k := range doc.Paths {
-						pathNames = append(pathNames, k)
+					if pathSpec.Post != nil {
+						table.Append([]string{apiName, rc.Name, version.String(), pathName, "POST", pathSpec.Post.OperationID})
 					}
-					sort.Strings(pathNames)
-					for _, pathName := range pathNames {
-						pathSpec := doc.Paths[pathName]
-						if pathSpec.Get != nil {
-							table.Append([]string{apiName, rc.Name(), version.String(), pathName, "GET", pathSpec.Get.OperationID})
-						}
-						if pathSpec.Post != nil {
-							table.Append([]string{apiName, rc.Name(), version.String(), pathName, "POST", pathSpec.Post.OperationID})
-						}
-						if pathSpec.Put != nil {
-							table.Append([]string{apiName, rc.Name(), version.String(), pathName, "PUT", pathSpec.Put.OperationID})
-						}
-						if pathSpec.Patch != nil {
-							table.Append([]string{apiName, rc.Name(), version.String(), pathName, "PATCH", pathSpec.Patch.OperationID})
-						}
-						if pathSpec.Delete != nil {
-							table.Append([]string{apiName, rc.Name(), version.String(), pathName, "DELETE", pathSpec.Delete.OperationID})
-						}
+					if pathSpec.Put != nil {
+						table.Append([]string{apiName, rc.Name, version.String(), pathName, "PUT", pathSpec.Put.OperationID})
+					}
+					if pathSpec.Patch != nil {
+						table.Append([]string{apiName, rc.Name, version.String(), pathName, "PATCH", pathSpec.Patch.OperationID})
+					}
+					if pathSpec.Delete != nil {
+						table.Append([]string{apiName, rc.Name, version.String(), pathName, "DELETE", pathSpec.Delete.OperationID})
 					}
 				}
 			}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -51,6 +51,7 @@ resources/_examples/hello-world/2021-06-01/spec.yaml
 resources/_examples/hello-world/2021-06-07/spec.yaml
 resources/_examples/hello-world/2021-06-13/spec.yaml
 resources/projects/2021-06-04/spec.yaml
+resources/projects/2021-08-20/spec.yaml
 `[1:])
 }
 
@@ -70,15 +71,16 @@ func TestVersionList(t *testing.T) {
 	out, err := ioutil.ReadFile(tmpFile)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(out), qt.Equals, `
-+----------+-------------+-------------------------+----------------------------+--------+------------------+
-|   API    |  RESOURCE   |         VERSION         |            PATH            | METHOD |    OPERATION     |
-+----------+-------------+-------------------------+----------------------------+--------+------------------+
-| testdata | hello-world | 2021-06-01~experimental | /examples/hello-world/{id} | GET    | helloWorldGetOne |
-| testdata | hello-world | 2021-06-07~experimental | /examples/hello-world/{id} | GET    | helloWorldGetOne |
-| testdata | hello-world | 2021-06-13~beta         | /examples/hello-world      | POST   | helloWorldCreate |
-| testdata | hello-world | 2021-06-13~beta         | /examples/hello-world/{id} | GET    | helloWorldGetOne |
-| testdata | projects    | 2021-06-04~experimental | /orgs/{orgId}/projects     | GET    | getOrgsProjects  |
-+----------+-------------+-------------------------+----------------------------+--------+------------------+
++----------+-------------+-------------------------+--------------------------------------+--------+-------------------+
+|   API    |  RESOURCE   |         VERSION         |                 PATH                 | METHOD |     OPERATION     |
++----------+-------------+-------------------------+--------------------------------------+--------+-------------------+
+| testdata | hello-world | 2021-06-01~experimental | /examples/hello-world/{id}           | GET    | helloWorldGetOne  |
+| testdata | projects    | 2021-06-04~experimental | /orgs/{orgId}/projects               | GET    | getOrgsProjects   |
+| testdata | hello-world | 2021-06-07~experimental | /examples/hello-world/{id}           | GET    | helloWorldGetOne  |
+| testdata | hello-world | 2021-06-13~beta         | /examples/hello-world                | POST   | helloWorldCreate  |
+| testdata | hello-world | 2021-06-13~beta         | /examples/hello-world/{id}           | GET    | helloWorldGetOne  |
+| testdata | projects    | 2021-08-20~experimental | /orgs/{org_id}/projects/{project_id} | DELETE | deleteOrgsProject |
++----------+-------------+-------------------------+--------------------------------------+--------+-------------------+
 `[1:])
 }
 

--- a/resource_test.go
+++ b/resource_test.go
@@ -60,7 +60,7 @@ func TestVersionRangesProjects(t *testing.T) {
 	c := qt.New(t)
 	eps, err := LoadResourceVersions(testdata.Path("resources/projects"))
 	c.Assert(err, qt.IsNil)
-	c.Assert(eps.Versions(), qt.HasLen, 1)
+	c.Assert(eps.Versions(), qt.HasLen, 2)
 	tests := []struct {
 		query, match, err string
 	}{{

--- a/resource_versions.go
+++ b/resource_versions.go
@@ -1,0 +1,81 @@
+package vervet
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+type resourceVersionsSlice []*ResourceVersions
+
+func (s resourceVersionsSlice) validate() error {
+	for _, v := range s.versions() {
+		resourcePaths := map[string]string{}
+		for _, eps := range s {
+			ep, err := eps.At(v.String())
+			if err == ErrNoMatchingVersion {
+				continue
+			} else if err != nil {
+				return fmt.Errorf("validation failed: %w", err)
+			}
+			for path := range ep.Paths {
+				if conflict, ok := resourcePaths[path]; ok {
+					return fmt.Errorf("conflict: %q %q", conflict, ep.sourcePrefix)
+				}
+				resourcePaths[path] = ep.sourcePrefix
+			}
+		}
+	}
+	return nil
+}
+
+func (s resourceVersionsSlice) versions() VersionSlice {
+	vset := map[Version]bool{}
+	for _, eps := range s {
+		for i := range eps.versions {
+			vset[eps.versions[i].Version] = true
+		}
+	}
+	var versions VersionSlice
+	for v := range vset {
+		versions = append(versions, v)
+	}
+	sort.Sort(versions)
+	return versions
+}
+
+func (s resourceVersionsSlice) at(v Version) (*openapi3.T, error) {
+	var result *openapi3.T
+	for _, eps := range s {
+		ep, err := eps.At(v.String())
+		if err == ErrNoMatchingVersion {
+			continue
+		} else if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			// Assign a clean copy of the contents of the first resource to the
+			// resulting spec. Marshaling is used to ensure that references in
+			// the source resource are dropped from the result, which could be
+			// modified on subsequent merges.
+			buf, err := ep.T.MarshalJSON()
+			if err != nil {
+				return nil, err
+			}
+			result = &openapi3.T{}
+			err = result.UnmarshalJSON(buf)
+			if err != nil {
+				return nil, err
+			}
+		}
+		Merge(result, ep.T, false)
+	}
+	if result == nil {
+		return nil, ErrNoMatchingVersion
+	}
+	// Remove the API stability extension from the merged OpenAPI spec, this
+	// extension is only applicable to individual resource version specs.
+	delete(result.ExtensionProps.Extensions, ExtSnykApiStability)
+	return result, nil
+}

--- a/spec_test.go
+++ b/spec_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/getkin/kin-openapi/openapi3"
 
 	. "github.com/snyk/vervet"
 	"github.com/snyk/vervet/testdata"
@@ -14,72 +15,102 @@ func TestSpecs(t *testing.T) {
 	specs, err := LoadSpecVersions(testdata.Path("resources"))
 	c.Assert(err, qt.IsNil)
 	versions := specs.Versions()
-	c.Assert(versions, qt.HasLen, 4)
-	c.Assert(versions, qt.ContentEquals, []Version{
+	c.Assert(versions, qt.ContentEquals, VersionSlice{
 		MustParseVersion("2021-06-01~experimental"),
 		MustParseVersion("2021-06-04~experimental"),
 		MustParseVersion("2021-06-07~experimental"),
+		MustParseVersion("2021-06-13~experimental"),
 		MustParseVersion("2021-06-13~beta"),
+		MustParseVersion("2021-08-20~experimental"),
+		MustParseVersion("2021-08-20~beta"),
 	})
 
 	type expectResourceVersion struct {
 		version string
 		path    string
+		opFunc  func(*openapi3.PathItem) *openapi3.Operation
 	}
 	tests := []struct {
-		query       string
-		hasVersions []expectResourceVersion
+		query, match string
+		hasVersions  []expectResourceVersion
+		err          string
 	}{{
 		query: "2021-07-01~experimental",
+		match: "2021-06-13~experimental",
 		hasVersions: []expectResourceVersion{{
 			version: "2021-06-13~beta",
 			path:    "/examples/hello-world",
+			opFunc:  func(p *openapi3.PathItem) *openapi3.Operation { return p.Post },
 		}, {
 			version: "2021-06-13~beta",
 			path:    "/examples/hello-world/{id}",
+			opFunc:  func(p *openapi3.PathItem) *openapi3.Operation { return p.Get },
 		}, {
 			version: "2021-06-04~experimental",
 			path:    "/orgs/{orgId}/projects",
+			opFunc:  func(p *openapi3.PathItem) *openapi3.Operation { return p.Get },
+		}},
+	}, {
+		query: "2021-09-01~experimental",
+		match: "2021-08-20~experimental",
+		hasVersions: []expectResourceVersion{{
+			version: "2021-06-13~beta",
+			path:    "/examples/hello-world",
+			opFunc:  func(p *openapi3.PathItem) *openapi3.Operation { return p.Post },
+		}, {
+			version: "2021-06-13~beta",
+			path:    "/examples/hello-world/{id}",
+			opFunc:  func(p *openapi3.PathItem) *openapi3.Operation { return p.Get },
+		}, {
+			version: "2021-06-04~experimental",
+			path:    "/orgs/{orgId}/projects",
+			opFunc:  func(p *openapi3.PathItem) *openapi3.Operation { return p.Get },
+		}, {
+			version: "2021-08-20~experimental",
+			path:    "/orgs/{org_id}/projects/{project_id}",
+			opFunc:  func(p *openapi3.PathItem) *openapi3.Operation { return p.Delete },
 		}},
 	}, {
 		query: "2021-07-01~wip",
-		hasVersions: []expectResourceVersion{{
-			version: "2021-06-13~beta",
-			path:    "/examples/hello-world",
-		}, {
-			version: "2021-06-13~beta",
-			path:    "/examples/hello-world/{id}",
-		}, {
-			version: "2021-06-04~experimental",
-			path:    "/orgs/{orgId}/projects",
-		}},
+		err:   "no matching version",
+	}, {
+		query: "2021-06-01",
+		err:   "no matching version",
 	}, {
 		query: "2021-07-01~beta",
+		match: "2021-06-13~beta",
 		hasVersions: []expectResourceVersion{{
 			version: "2021-06-13~beta",
 			path:    "/examples/hello-world",
+			opFunc:  func(p *openapi3.PathItem) *openapi3.Operation { return p.Post },
 		}, {
 			version: "2021-06-13~beta",
 			path:    "/examples/hello-world/{id}",
+			opFunc:  func(p *openapi3.PathItem) *openapi3.Operation { return p.Get },
 		}},
 	}}
 	for i, t := range tests {
 		c.Logf("test#%d: %#v", i, t)
-		spec, err := specs.At(t.query)
+		spec, err := specs.At(MustParseVersion(t.query))
+		if t.err != "" {
+			c.Assert(err, qt.ErrorMatches, t.err)
+			continue
+		}
 		c.Assert(err, qt.IsNil)
 		_, err = ExtensionString(spec.ExtensionProps, ExtSnykApiStability)
 		c.Assert(err, qt.ErrorMatches, `extension "x-snyk-api-stability" not found`)
 		c.Assert(IsExtensionNotFound(err), qt.IsTrue)
-		m := map[expectResourceVersion]bool{}
-		for path, pathItem := range spec.Paths {
-			pathVersionStr, err := ExtensionString(pathItem.ExtensionProps, ExtSnykApiVersion)
+		version, err := ExtensionString(spec.ExtensionProps, ExtSnykApiVersion)
+		c.Assert(err, qt.IsNil)
+		c.Assert(version, qt.Equals, t.match)
+		for _, expected := range t.hasVersions {
+			pathItem := spec.Paths[expected.path]
+			c.Assert(pathItem, qt.Not(qt.IsNil))
+			op := expected.opFunc(pathItem)
+			c.Assert(op, qt.Not(qt.IsNil))
+			versionStr, err := ExtensionString(op.ExtensionProps, ExtSnykApiVersion)
 			c.Assert(err, qt.IsNil)
-			c.Assert(IsExtensionNotFound(err), qt.IsFalse)
-			m[expectResourceVersion{version: pathVersionStr, path: path}] = true
-		}
-		c.Assert(m, qt.HasLen, len(t.hasVersions))
-		for _, hasVersion := range t.hasVersions {
-			c.Assert(m[hasVersion], qt.IsTrue)
+			c.Assert(versionStr, qt.Equals, expected.version)
 		}
 	}
 }

--- a/testdata/output/2021-06-01~experimental/spec.json
+++ b/testdata/output/2021-06-01~experimental/spec.json
@@ -392,17 +392,17 @@
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }
+        },
+        "x-snyk-api-releases": [
+          "2021-06-01~experimental",
+          "2021-06-07~experimental",
+          "2021-06-13~beta"
+        ],
+        "x-snyk-api-version": "2021-06-01~experimental",
+        "x-snyk-deprecated-by": "2021-06-07~experimental",
+        "x-snyk-sunset-eligible": "2021-07-08"
       },
-      "x-snyk-api-releases": [
-        "2021-06-01~experimental",
-        "2021-06-07~experimental",
-        "2021-06-13~beta"
-      ],
-      "x-snyk-api-resource": "hello-world",
-      "x-snyk-api-version": "2021-06-01~experimental",
-      "x-snyk-deprecated-by": "2021-06-07~experimental",
-      "x-snyk-sunset-eligible": "2021-07-08"
+      "x-snyk-api-resource": "hello-world"
     },
     "/openapi": {
       "get": {
@@ -511,5 +511,6 @@
       "description": "Test API v3",
       "url": "https://example.com/api/v3"
     }
-  ]
+  ],
+  "x-snyk-api-version": "2021-06-01~experimental"
 }

--- a/testdata/output/2021-06-01~experimental/spec.yaml
+++ b/testdata/output/2021-06-01~experimental/spec.yaml
@@ -267,14 +267,14 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
-    x-snyk-api-releases:
-    - 2021-06-01~experimental
-    - 2021-06-07~experimental
-    - 2021-06-13~beta
+      x-snyk-api-releases:
+      - 2021-06-01~experimental
+      - 2021-06-07~experimental
+      - 2021-06-13~beta
+      x-snyk-api-version: 2021-06-01~experimental
+      x-snyk-deprecated-by: 2021-06-07~experimental
+      x-snyk-sunset-eligible: "2021-07-08"
     x-snyk-api-resource: hello-world
-    x-snyk-api-version: 2021-06-01~experimental
-    x-snyk-deprecated-by: 2021-06-07~experimental
-    x-snyk-sunset-eligible: "2021-07-08"
   /openapi:
     get:
       description: List available versions of OpenAPI specification
@@ -342,3 +342,4 @@ paths:
 servers:
 - description: Test API v3
   url: https://example.com/api/v3
+x-snyk-api-version: 2021-06-01~experimental

--- a/testdata/output/2021-06-04~experimental/spec.yaml
+++ b/testdata/output/2021-06-04~experimental/spec.yaml
@@ -316,14 +316,14 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
-    x-snyk-api-releases:
-    - 2021-06-01~experimental
-    - 2021-06-07~experimental
-    - 2021-06-13~beta
+      x-snyk-api-releases:
+      - 2021-06-01~experimental
+      - 2021-06-07~experimental
+      - 2021-06-13~beta
+      x-snyk-api-version: 2021-06-01~experimental
+      x-snyk-deprecated-by: 2021-06-07~experimental
+      x-snyk-sunset-eligible: "2021-07-08"
     x-snyk-api-resource: hello-world
-    x-snyk-api-version: 2021-06-01~experimental
-    x-snyk-deprecated-by: 2021-06-07~experimental
-    x-snyk-sunset-eligible: "2021-07-08"
   /openapi:
     get:
       description: List available versions of OpenAPI specification
@@ -471,10 +471,11 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
-    x-snyk-api-releases:
-    - 2021-06-04~experimental
+      x-snyk-api-releases:
+      - 2021-06-04~experimental
+      x-snyk-api-version: 2021-06-04~experimental
     x-snyk-api-resource: projects
-    x-snyk-api-version: 2021-06-04~experimental
 servers:
 - description: Test API v3
   url: https://example.com/api/v3
+x-snyk-api-version: 2021-06-04~experimental

--- a/testdata/output/2021-06-07~experimental/spec.json
+++ b/testdata/output/2021-06-07~experimental/spec.json
@@ -454,17 +454,17 @@
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }
+        },
+        "x-snyk-api-releases": [
+          "2021-06-01~experimental",
+          "2021-06-07~experimental",
+          "2021-06-13~beta"
+        ],
+        "x-snyk-api-version": "2021-06-07~experimental",
+        "x-snyk-deprecated-by": "2021-06-13~beta",
+        "x-snyk-sunset-eligible": "2021-07-14"
       },
-      "x-snyk-api-releases": [
-        "2021-06-01~experimental",
-        "2021-06-07~experimental",
-        "2021-06-13~beta"
-      ],
-      "x-snyk-api-resource": "hello-world",
-      "x-snyk-api-version": "2021-06-07~experimental",
-      "x-snyk-deprecated-by": "2021-06-13~beta",
-      "x-snyk-sunset-eligible": "2021-07-14"
+      "x-snyk-api-resource": "hello-world"
     },
     "/openapi": {
       "get": {
@@ -693,13 +693,13 @@
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }
+        },
+        "x-snyk-api-releases": [
+          "2021-06-04~experimental"
+        ],
+        "x-snyk-api-version": "2021-06-04~experimental"
       },
-      "x-snyk-api-releases": [
-        "2021-06-04~experimental"
-      ],
-      "x-snyk-api-resource": "projects",
-      "x-snyk-api-version": "2021-06-04~experimental"
+      "x-snyk-api-resource": "projects"
     }
   },
   "servers": [
@@ -707,5 +707,6 @@
       "description": "Test API v3",
       "url": "https://example.com/api/v3"
     }
-  ]
+  ],
+  "x-snyk-api-version": "2021-06-07~experimental"
 }

--- a/testdata/output/2021-06-13~beta/spec.json
+++ b/testdata/output/2021-06-13~beta/spec.json
@@ -411,13 +411,13 @@
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }
+        },
+        "x-snyk-api-releases": [
+          "2021-06-13~beta"
+        ],
+        "x-snyk-api-version": "2021-06-13~beta"
       },
-      "x-snyk-api-releases": [
-        "2021-06-13~beta"
-      ],
-      "x-snyk-api-resource": "hello-world",
-      "x-snyk-api-version": "2021-06-13~beta"
+      "x-snyk-api-resource": "hello-world"
     },
     "/examples/hello-world/{id}": {
       "get": {
@@ -491,15 +491,15 @@
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }
+        },
+        "x-snyk-api-releases": [
+          "2021-06-01~experimental",
+          "2021-06-07~experimental",
+          "2021-06-13~beta"
+        ],
+        "x-snyk-api-version": "2021-06-13~beta"
       },
-      "x-snyk-api-releases": [
-        "2021-06-01~experimental",
-        "2021-06-07~experimental",
-        "2021-06-13~beta"
-      ],
-      "x-snyk-api-resource": "hello-world",
-      "x-snyk-api-version": "2021-06-13~beta"
+      "x-snyk-api-resource": "hello-world"
     },
     "/openapi": {
       "get": {
@@ -608,5 +608,6 @@
       "description": "Test API v3",
       "url": "https://example.com/api/v3"
     }
-  ]
+  ],
+  "x-snyk-api-version": "2021-06-13~beta"
 }

--- a/testdata/output/2021-06-13~beta/spec.yaml
+++ b/testdata/output/2021-06-13~beta/spec.yaml
@@ -280,10 +280,10 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
-    x-snyk-api-releases:
-    - 2021-06-13~beta
+      x-snyk-api-releases:
+      - 2021-06-13~beta
+      x-snyk-api-version: 2021-06-13~beta
     x-snyk-api-resource: hello-world
-    x-snyk-api-version: 2021-06-13~beta
   /examples/hello-world/{id}:
     get:
       description: Get a single result from the hello-world example
@@ -331,12 +331,12 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
-    x-snyk-api-releases:
-    - 2021-06-01~experimental
-    - 2021-06-07~experimental
-    - 2021-06-13~beta
+      x-snyk-api-releases:
+      - 2021-06-01~experimental
+      - 2021-06-07~experimental
+      - 2021-06-13~beta
+      x-snyk-api-version: 2021-06-13~beta
     x-snyk-api-resource: hello-world
-    x-snyk-api-version: 2021-06-13~beta
   /openapi:
     get:
       description: List available versions of OpenAPI specification
@@ -404,3 +404,4 @@ paths:
 servers:
 - description: Test API v3
   url: https://example.com/api/v3
+x-snyk-api-version: 2021-06-13~beta

--- a/testdata/output/2021-06-13~experimental/spec.json
+++ b/testdata/output/2021-06-13~experimental/spec.json
@@ -473,13 +473,13 @@
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }
+        },
+        "x-snyk-api-releases": [
+          "2021-06-13~beta"
+        ],
+        "x-snyk-api-version": "2021-06-13~beta"
       },
-      "x-snyk-api-releases": [
-        "2021-06-13~beta"
-      ],
-      "x-snyk-api-resource": "hello-world",
-      "x-snyk-api-version": "2021-06-13~beta"
+      "x-snyk-api-resource": "hello-world"
     },
     "/examples/hello-world/{id}": {
       "get": {
@@ -553,15 +553,15 @@
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }
+        },
+        "x-snyk-api-releases": [
+          "2021-06-01~experimental",
+          "2021-06-07~experimental",
+          "2021-06-13~beta"
+        ],
+        "x-snyk-api-version": "2021-06-13~beta"
       },
-      "x-snyk-api-releases": [
-        "2021-06-01~experimental",
-        "2021-06-07~experimental",
-        "2021-06-13~beta"
-      ],
-      "x-snyk-api-resource": "hello-world",
-      "x-snyk-api-version": "2021-06-13~beta"
+      "x-snyk-api-resource": "hello-world"
     },
     "/openapi": {
       "get": {
@@ -790,13 +790,13 @@
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }
+        },
+        "x-snyk-api-releases": [
+          "2021-06-04~experimental"
+        ],
+        "x-snyk-api-version": "2021-06-04~experimental"
       },
-      "x-snyk-api-releases": [
-        "2021-06-04~experimental"
-      ],
-      "x-snyk-api-resource": "projects",
-      "x-snyk-api-version": "2021-06-04~experimental"
+      "x-snyk-api-resource": "projects"
     }
   },
   "servers": [
@@ -804,5 +804,6 @@
       "description": "Test API v3",
       "url": "https://example.com/api/v3"
     }
-  ]
+  ],
+  "x-snyk-api-version": "2021-06-13~experimental"
 }

--- a/testdata/output/2021-06-13~experimental/spec.yaml
+++ b/testdata/output/2021-06-13~experimental/spec.yaml
@@ -329,10 +329,10 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
-    x-snyk-api-releases:
-    - 2021-06-13~beta
+      x-snyk-api-releases:
+      - 2021-06-13~beta
+      x-snyk-api-version: 2021-06-13~beta
     x-snyk-api-resource: hello-world
-    x-snyk-api-version: 2021-06-13~beta
   /examples/hello-world/{id}:
     get:
       description: Get a single result from the hello-world example
@@ -380,12 +380,12 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
-    x-snyk-api-releases:
-    - 2021-06-01~experimental
-    - 2021-06-07~experimental
-    - 2021-06-13~beta
+      x-snyk-api-releases:
+      - 2021-06-01~experimental
+      - 2021-06-07~experimental
+      - 2021-06-13~beta
+      x-snyk-api-version: 2021-06-13~beta
     x-snyk-api-resource: hello-world
-    x-snyk-api-version: 2021-06-13~beta
   /openapi:
     get:
       description: List available versions of OpenAPI specification
@@ -533,10 +533,11 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
-    x-snyk-api-releases:
-    - 2021-06-04~experimental
+      x-snyk-api-releases:
+      - 2021-06-04~experimental
+      x-snyk-api-version: 2021-06-04~experimental
     x-snyk-api-resource: projects
-    x-snyk-api-version: 2021-06-04~experimental
 servers:
 - description: Test API v3
   url: https://example.com/api/v3
+x-snyk-api-version: 2021-06-13~experimental

--- a/testdata/output/2021-08-20~beta/spec.json
+++ b/testdata/output/2021-08-20~beta/spec.json
@@ -308,68 +308,6 @@
         },
         "type": "object"
       },
-      "Project": {
-        "additionalProperties": false,
-        "properties": {
-          "attributes": {
-            "additionalProperties": false,
-            "properties": {
-              "created": {
-                "description": "The date that the project was created on",
-                "example": "2021-05-29T09:50:54.014Z",
-                "type": "string"
-              },
-              "hostname": {
-                "description": "The hostname for a CLI project, null if not set",
-                "nullable": true,
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "origin": {
-                "description": "The origin the project was added from",
-                "example": "github",
-                "type": "string"
-              },
-              "status": {
-                "description": "Describes if a project is currently monitored or it is de-activated",
-                "example": "active",
-                "type": "string"
-              },
-              "type": {
-                "description": "The package manager of the project",
-                "example": "maven",
-                "type": "string"
-              }
-            },
-            "required": [
-              "name",
-              "created",
-              "origin",
-              "type",
-              "status"
-            ],
-            "type": "object"
-          },
-          "id": {
-            "description": "The ID.",
-            "example": "331ede0a-de94-456f-b788-166caeca58bf",
-            "type": "string"
-          },
-          "type": {
-            "description": "Content type.",
-            "example": "projects",
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "id",
-          "attributes"
-        ],
-        "type": "object"
-      },
       "Version": {
         "pattern": "^(wip|work-in-progress|experimental|beta|(([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9])))$",
         "type": "string"
@@ -382,6 +320,105 @@
   },
   "openapi": "3.0.3",
   "paths": {
+    "/examples/hello-world": {
+      "post": {
+        "description": "Create a single result from the hello-world example",
+        "operationId": "helloWorldCreate",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Version"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "attributes": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "betaField": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "betaField"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "attributes"
+                ],
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/HelloWorld"
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/JSONAPI"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/Links"
+                    }
+                  },
+                  "required": [
+                    "jsonapi",
+                    "data",
+                    "links"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "A hello world entity being requested is returned",
+            "headers": {
+              "snyk-request-id": {
+                "$ref": "#/components/headers/RequestIDResponseHeader"
+              },
+              "snyk-version-requested": {
+                "$ref": "#/components/headers/VersionRequestedResponseHeader"
+              },
+              "snyk-version-served": {
+                "$ref": "#/components/headers/VersionServedResponseHeader"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "x-snyk-api-releases": [
+          "2021-06-13~beta"
+        ],
+        "x-snyk-api-version": "2021-06-13~beta"
+      },
+      "x-snyk-api-resource": "hello-world"
+    },
     "/examples/hello-world/{id}": {
       "get": {
         "description": "Get a single result from the hello-world example",
@@ -460,9 +497,7 @@
           "2021-06-07~experimental",
           "2021-06-13~beta"
         ],
-        "x-snyk-api-version": "2021-06-01~experimental",
-        "x-snyk-deprecated-by": "2021-06-07~experimental",
-        "x-snyk-sunset-eligible": "2021-07-08"
+        "x-snyk-api-version": "2021-06-13~beta"
       },
       "x-snyk-api-resource": "hello-world"
     },
@@ -566,140 +601,6 @@
           }
         }
       }
-    },
-    "/orgs/{orgId}/projects": {
-      "get": {
-        "description": "Get a list of an organization's projects.",
-        "operationId": "getOrgsProjects",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/Version"
-          },
-          {
-            "$ref": "#/components/parameters/Pagination"
-          },
-          {
-            "description": "The id of the org to return a list of projects",
-            "in": "path",
-            "name": "orgId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The options for filtering the result set",
-            "in": "query",
-            "name": "filters",
-            "schema": {
-              "additionalProperties": false,
-              "properties": {
-                "attributes.criticality": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "attributes.environment": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "attributes.lifecycle": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "origin": {
-                  "type": "string"
-                },
-                "status": {
-                  "enum": [
-                    "active",
-                    "inactive"
-                  ],
-                  "type": "string"
-                },
-                "tags.includes": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "type": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "data": {
-                      "items": {
-                        "$ref": "#/components/schemas/Project"
-                      },
-                      "type": "array"
-                    },
-                    "jsonapi": {
-                      "$ref": "#/components/schemas/JSONAPI"
-                    },
-                    "links": {
-                      "$ref": "#/components/schemas/Links"
-                    }
-                  },
-                  "required": [
-                    "jsonapi",
-                    "data",
-                    "links"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "A list of projects is returned for the targeted org",
-            "headers": {
-              "snyk-request-id": {
-                "$ref": "#/components/headers/RequestIDResponseHeader"
-              },
-              "snyk-version-requested": {
-                "$ref": "#/components/headers/VersionRequestedResponseHeader"
-              },
-              "snyk-version-served": {
-                "$ref": "#/components/headers/VersionServedResponseHeader"
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "x-snyk-api-releases": [
-          "2021-06-04~experimental"
-        ],
-        "x-snyk-api-version": "2021-06-04~experimental"
-      },
-      "x-snyk-api-resource": "projects"
     }
   },
   "servers": [
@@ -708,5 +609,5 @@
       "url": "https://example.com/api/v3"
     }
   ],
-  "x-snyk-api-version": "2021-06-04~experimental"
+  "x-snyk-api-version": "2021-08-20~beta"
 }

--- a/testdata/output/2021-08-20~beta/spec.yaml
+++ b/testdata/output/2021-08-20~beta/spec.yaml
@@ -212,55 +212,6 @@ components:
         self:
           $ref: '#/components/schemas/LinkProperty'
       type: object
-    Project:
-      additionalProperties: false
-      properties:
-        attributes:
-          additionalProperties: false
-          properties:
-            created:
-              description: The date that the project was created on
-              example: "2021-05-29T09:50:54.014Z"
-              type: string
-            hostname:
-              description: The hostname for a CLI project, null if not set
-              nullable: true
-              type: string
-            name:
-              type: string
-            origin:
-              description: The origin the project was added from
-              example: github
-              type: string
-            status:
-              description: Describes if a project is currently monitored or it is
-                de-activated
-              example: active
-              type: string
-            type:
-              description: The package manager of the project
-              example: maven
-              type: string
-          required:
-          - name
-          - created
-          - origin
-          - type
-          - status
-          type: object
-        id:
-          description: The ID.
-          example: 331ede0a-de94-456f-b788-166caeca58bf
-          type: string
-        type:
-          description: Content type.
-          example: projects
-          type: string
-      required:
-      - type
-      - id
-      - attributes
-      type: object
     Version:
       pattern: ^(wip|work-in-progress|experimental|beta|(([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9])))$
       type: string
@@ -269,6 +220,70 @@ info:
   version: 3.0.0
 openapi: 3.0.3
 paths:
+  /examples/hello-world:
+    post:
+      description: Create a single result from the hello-world example
+      operationId: helloWorldCreate
+      parameters:
+      - $ref: '#/components/parameters/Version'
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              additionalProperties: false
+              properties:
+                attributes:
+                  additionalProperties: false
+                  properties:
+                    betaField:
+                      type: string
+                    message:
+                      type: string
+                  required:
+                  - message
+                  - betaField
+                  type: object
+              required:
+              - attributes
+              type: object
+      responses:
+        "201":
+          content:
+            application/vnd.api+json:
+              schema:
+                additionalProperties: false
+                properties:
+                  data:
+                    $ref: '#/components/schemas/HelloWorld'
+                  jsonapi:
+                    $ref: '#/components/schemas/JSONAPI'
+                  links:
+                    $ref: '#/components/schemas/Links'
+                required:
+                - jsonapi
+                - data
+                - links
+                type: object
+          description: A hello world entity being requested is returned
+          headers:
+            snyk-request-id:
+              $ref: '#/components/headers/RequestIDResponseHeader'
+            snyk-version-requested:
+              $ref: '#/components/headers/VersionRequestedResponseHeader'
+            snyk-version-served:
+              $ref: '#/components/headers/VersionServedResponseHeader'
+        "400":
+          $ref: '#/components/responses/400'
+        "401":
+          $ref: '#/components/responses/401'
+        "404":
+          $ref: '#/components/responses/404'
+        "500":
+          $ref: '#/components/responses/500'
+      x-snyk-api-releases:
+      - 2021-06-13~beta
+      x-snyk-api-version: 2021-06-13~beta
+    x-snyk-api-resource: hello-world
   /examples/hello-world/{id}:
     get:
       description: Get a single result from the hello-world example
@@ -320,9 +335,7 @@ paths:
       - 2021-06-01~experimental
       - 2021-06-07~experimental
       - 2021-06-13~beta
-      x-snyk-api-version: 2021-06-07~experimental
-      x-snyk-deprecated-by: 2021-06-13~beta
-      x-snyk-sunset-eligible: "2021-07-14"
+      x-snyk-api-version: 2021-06-13~beta
     x-snyk-api-resource: hello-world
   /openapi:
     get:
@@ -388,94 +401,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
-  /orgs/{orgId}/projects:
-    get:
-      description: Get a list of an organization's projects.
-      operationId: getOrgsProjects
-      parameters:
-      - $ref: '#/components/parameters/Version'
-      - $ref: '#/components/parameters/Pagination'
-      - description: The id of the org to return a list of projects
-        in: path
-        name: orgId
-        required: true
-        schema:
-          type: string
-      - description: The options for filtering the result set
-        in: query
-        name: filters
-        schema:
-          additionalProperties: false
-          properties:
-            attributes.criticality:
-              items:
-                type: string
-              type: array
-            attributes.environment:
-              items:
-                type: string
-              type: array
-            attributes.lifecycle:
-              items:
-                type: string
-              type: array
-            name:
-              type: string
-            origin:
-              type: string
-            status:
-              enum:
-              - active
-              - inactive
-              type: string
-            tags.includes:
-              items:
-                type: string
-              type: array
-            type:
-              type: string
-          type: object
-      responses:
-        "200":
-          content:
-            application/vnd.api+json:
-              schema:
-                additionalProperties: false
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/Project'
-                    type: array
-                  jsonapi:
-                    $ref: '#/components/schemas/JSONAPI'
-                  links:
-                    $ref: '#/components/schemas/Links'
-                required:
-                - jsonapi
-                - data
-                - links
-                type: object
-          description: A list of projects is returned for the targeted org
-          headers:
-            snyk-request-id:
-              $ref: '#/components/headers/RequestIDResponseHeader'
-            snyk-version-requested:
-              $ref: '#/components/headers/VersionRequestedResponseHeader'
-            snyk-version-served:
-              $ref: '#/components/headers/VersionServedResponseHeader'
-        "400":
-          $ref: '#/components/responses/400'
-        "401":
-          $ref: '#/components/responses/401'
-        "404":
-          $ref: '#/components/responses/404'
-        "500":
-          $ref: '#/components/responses/500'
-      x-snyk-api-releases:
-      - 2021-06-04~experimental
-      x-snyk-api-version: 2021-06-04~experimental
-    x-snyk-api-resource: projects
 servers:
 - description: Test API v3
   url: https://example.com/api/v3
-x-snyk-api-version: 2021-06-07~experimental
+x-snyk-api-version: 2021-08-20~beta

--- a/testdata/output/2021-08-20~experimental/spec.json
+++ b/testdata/output/2021-08-20~experimental/spec.json
@@ -382,6 +382,105 @@
   },
   "openapi": "3.0.3",
   "paths": {
+    "/examples/hello-world": {
+      "post": {
+        "description": "Create a single result from the hello-world example",
+        "operationId": "helloWorldCreate",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Version"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "attributes": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "betaField": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "betaField"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "attributes"
+                ],
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/HelloWorld"
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/JSONAPI"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/Links"
+                    }
+                  },
+                  "required": [
+                    "jsonapi",
+                    "data",
+                    "links"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "A hello world entity being requested is returned",
+            "headers": {
+              "snyk-request-id": {
+                "$ref": "#/components/headers/RequestIDResponseHeader"
+              },
+              "snyk-version-requested": {
+                "$ref": "#/components/headers/VersionRequestedResponseHeader"
+              },
+              "snyk-version-served": {
+                "$ref": "#/components/headers/VersionServedResponseHeader"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "x-snyk-api-releases": [
+          "2021-06-13~beta"
+        ],
+        "x-snyk-api-version": "2021-06-13~beta"
+      },
+      "x-snyk-api-resource": "hello-world"
+    },
     "/examples/hello-world/{id}": {
       "get": {
         "description": "Get a single result from the hello-world example",
@@ -460,9 +559,7 @@
           "2021-06-07~experimental",
           "2021-06-13~beta"
         ],
-        "x-snyk-api-version": "2021-06-01~experimental",
-        "x-snyk-deprecated-by": "2021-06-07~experimental",
-        "x-snyk-sunset-eligible": "2021-07-08"
+        "x-snyk-api-version": "2021-06-13~beta"
       },
       "x-snyk-api-resource": "hello-world"
     },
@@ -700,6 +797,68 @@
         "x-snyk-api-version": "2021-06-04~experimental"
       },
       "x-snyk-api-resource": "projects"
+    },
+    "/orgs/{org_id}/projects/{project_id}": {
+      "delete": {
+        "description": "Delete an organization's project.",
+        "operationId": "deleteOrgsProject",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Version"
+          },
+          {
+            "description": "The id of the org containing the project",
+            "in": "path",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The id of the project",
+            "in": "path",
+            "name": "project_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Project was deleted",
+            "headers": {
+              "snyk-request-id": {
+                "$ref": "#/components/headers/RequestIDResponseHeader"
+              },
+              "snyk-version-requested": {
+                "$ref": "#/components/headers/VersionRequestedResponseHeader"
+              },
+              "snyk-version-served": {
+                "$ref": "#/components/headers/VersionServedResponseHeader"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "x-snyk-api-releases": [
+          "2021-08-20~experimental"
+        ],
+        "x-snyk-api-version": "2021-08-20~experimental"
+      },
+      "x-snyk-api-resource": "projects"
     }
   },
   "servers": [
@@ -708,5 +867,5 @@
       "url": "https://example.com/api/v3"
     }
   ],
-  "x-snyk-api-version": "2021-06-04~experimental"
+  "x-snyk-api-version": "2021-08-20~experimental"
 }

--- a/testdata/output/2021-08-20~experimental/spec.yaml
+++ b/testdata/output/2021-08-20~experimental/spec.yaml
@@ -269,6 +269,70 @@ info:
   version: 3.0.0
 openapi: 3.0.3
 paths:
+  /examples/hello-world:
+    post:
+      description: Create a single result from the hello-world example
+      operationId: helloWorldCreate
+      parameters:
+      - $ref: '#/components/parameters/Version'
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              additionalProperties: false
+              properties:
+                attributes:
+                  additionalProperties: false
+                  properties:
+                    betaField:
+                      type: string
+                    message:
+                      type: string
+                  required:
+                  - message
+                  - betaField
+                  type: object
+              required:
+              - attributes
+              type: object
+      responses:
+        "201":
+          content:
+            application/vnd.api+json:
+              schema:
+                additionalProperties: false
+                properties:
+                  data:
+                    $ref: '#/components/schemas/HelloWorld'
+                  jsonapi:
+                    $ref: '#/components/schemas/JSONAPI'
+                  links:
+                    $ref: '#/components/schemas/Links'
+                required:
+                - jsonapi
+                - data
+                - links
+                type: object
+          description: A hello world entity being requested is returned
+          headers:
+            snyk-request-id:
+              $ref: '#/components/headers/RequestIDResponseHeader'
+            snyk-version-requested:
+              $ref: '#/components/headers/VersionRequestedResponseHeader'
+            snyk-version-served:
+              $ref: '#/components/headers/VersionServedResponseHeader'
+        "400":
+          $ref: '#/components/responses/400'
+        "401":
+          $ref: '#/components/responses/401'
+        "404":
+          $ref: '#/components/responses/404'
+        "500":
+          $ref: '#/components/responses/500'
+      x-snyk-api-releases:
+      - 2021-06-13~beta
+      x-snyk-api-version: 2021-06-13~beta
+    x-snyk-api-resource: hello-world
   /examples/hello-world/{id}:
     get:
       description: Get a single result from the hello-world example
@@ -320,9 +384,7 @@ paths:
       - 2021-06-01~experimental
       - 2021-06-07~experimental
       - 2021-06-13~beta
-      x-snyk-api-version: 2021-06-07~experimental
-      x-snyk-deprecated-by: 2021-06-13~beta
-      x-snyk-sunset-eligible: "2021-07-14"
+      x-snyk-api-version: 2021-06-13~beta
     x-snyk-api-resource: hello-world
   /openapi:
     get:
@@ -388,6 +450,46 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+  /orgs/{org_id}/projects/{project_id}:
+    delete:
+      description: Delete an organization's project.
+      operationId: deleteOrgsProject
+      parameters:
+      - $ref: '#/components/parameters/Version'
+      - description: The id of the org containing the project
+        in: path
+        name: org_id
+        required: true
+        schema:
+          type: string
+      - description: The id of the project
+        in: path
+        name: project_id
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: Project was deleted
+          headers:
+            snyk-request-id:
+              $ref: '#/components/headers/RequestIDResponseHeader'
+            snyk-version-requested:
+              $ref: '#/components/headers/VersionRequestedResponseHeader'
+            snyk-version-served:
+              $ref: '#/components/headers/VersionServedResponseHeader'
+        "400":
+          $ref: '#/components/responses/400'
+        "401":
+          $ref: '#/components/responses/401'
+        "404":
+          $ref: '#/components/responses/404'
+        "500":
+          $ref: '#/components/responses/500'
+      x-snyk-api-releases:
+      - 2021-08-20~experimental
+      x-snyk-api-version: 2021-08-20~experimental
+    x-snyk-api-resource: projects
   /orgs/{orgId}/projects:
     get:
       description: Get a list of an organization's projects.
@@ -478,4 +580,4 @@ paths:
 servers:
 - description: Test API v3
   url: https://example.com/api/v3
-x-snyk-api-version: 2021-06-07~experimental
+x-snyk-api-version: 2021-08-20~experimental

--- a/testdata/output/embed.go
+++ b/testdata/output/embed.go
@@ -15,4 +15,8 @@ import "embed"
 //go:embed 2021-06-13~experimental/spec.yaml
 //go:embed 2021-06-13~beta/spec.json
 //go:embed 2021-06-13~beta/spec.yaml
+//go:embed 2021-08-20~experimental/spec.json
+//go:embed 2021-08-20~experimental/spec.yaml
+//go:embed 2021-08-20~beta/spec.json
+//go:embed 2021-08-20~beta/spec.yaml
 var Versions embed.FS

--- a/testdata/resources/projects/2021-08-20/spec.yaml
+++ b/testdata/resources/projects/2021-08-20/spec.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.3
+x-snyk-api-stability: experimental
+info:
+  title: Registry
+  version: 3.0.0
+servers:
+  - url: /api/v3
+    description: Snyk Registry
+paths:
+  /orgs/{org_id}/projects/{project_id}:
+    delete:
+      description: Delete an organization's project.
+      operationId: deleteOrgsProject
+      parameters:
+        - { $ref: '../../schemas/parameters/version.yaml#/Version' }
+        - name: org_id
+          in: path
+          required: true
+          description: The id of the org containing the project
+          schema:
+            type: string
+        - name: project_id
+          in: path
+          required: true
+          description: The id of the project
+          schema:
+            type: string
+      responses:
+        '400': { $ref: '../../schemas/responses/400.yaml#/400' }
+        '401': { $ref: '../../schemas/responses/401.yaml#/401' }
+        '404': { $ref: '../../schemas/responses/404.yaml#/404' }
+        '500': { $ref: '../../schemas/responses/500.yaml#/500' }
+        '204':
+          description: 'Project was deleted'
+          x-snyk-include-headers: { $ref: '../../schemas/headers/common-response.yaml#/Common' }


### PR DESCRIPTION
Fixes #99, ~~#100~~ (see note below).

This changes how operation (path + method) are resolved and merged
across spec versions within a stability level.

Operations are now cumulative. Unless a particular operation (path +
method) is redefined or explicitly deprecated, past releases are assumed
to carry over to newer versions.

BREAKING CHANGE: This changes the behavior of the compiler and resulting
output. It's also a breaking API change, requiring a major version bump.
We do not anticipate any breaking changes to OpenAPI consumers.