### PR TITLE
fix: auto-release on landing into main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,12 +96,13 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run:
-          name: Build package
-          command: ./scripts/dist.bash
-      - run:
-          name: Release package
-          command: cd dist; npx semantic-release -b main --dry-run
+      - run: |-
+          go install github.com/smlx/ccv@latest
+          export VERSION=$(ccv)
+          if [ -z $(git tag -l $(ccv)) ]; then
+            ./scripts/dist.bash
+            ./scripts/release.bash
+          fi
 
 workflows:
   version: 2

--- a/scripts/dist.bash
+++ b/scripts/dist.bash
@@ -2,11 +2,16 @@
 set -eux
 cd $(dirname $0)/..
 
+# Require a version to be set
+[ -n "${VERSION}" ]
+
+# Ensure there is a GOPATH set
 if [ -z "${GOPATH:-}" ]; then
     tmp_gopath=$(mktemp -d)
     trap "chmod -R u+w $tmp_gopath; rm -rf $tmp_gopath" EXIT
     export GOPATH=$tmp_gopath
 fi
+export PATH=$GOPATH/bin:$PATH
 
 rm -rf dist
 
@@ -20,5 +25,6 @@ GOOS=windows GOARCH=amd64 go build -a -o ./dist/bin/vervet.exe ./cmd/vervet
 cp packaging/npm/passthrough.js dist/bin/vervet
 cp README.md LICENSE ATTRIBUTIONS dist/
 
-go get github.com/a8m/envsubst/cmd/envsubst
-VERSION=0.0.0 $GOPATH/bin/envsubst < packaging/npm/package.json.in > dist/package.json
+go install github.com/a8m/envsubst/cmd/envsubst@latest
+
+envsubst < packaging/npm/package.json.in > dist/package.json

--- a/scripts/release.bash
+++ b/scripts/release.bash
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -eux
+cd $(dirname $0)/..
+
+# Require a version to be set
+[ -n "${VERSION}" ]
+
+# Ensure there is a GOPATH set
+if [ -z "${GOPATH:-}" ]; then
+    tmp_gopath=$(mktemp -d)
+    trap "chmod -R u+w $tmp_gopath; rm -rf $tmp_gopath" EXIT
+    export GOPATH=$tmp_gopath
+fi
+export PATH=$GOPATH/bin:$PATH
+
+go install github.com/goreleaser/goreleaser@latest
+
+# Push tags
+git tag ${VERSION}
+git push --tags ${GIT_REMOTE:-origin}
+
+# Publish npm package
+(cd dist; npm publish)
+
+# Github release
+goreleaser release --rm-dist


### PR DESCRIPTION
Using ccv to derive a release version from conventional commit comments. Tagging, NPM-ing, and Github releasing from that if unreleased, on landing into main.