### PR TITLE
fix: running optic linter from docker

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -77,7 +77,7 @@ apis:
 			"ci-rules": {
 				Name: "ci-rules",
 				OpticCI: &config.OpticCILinter{
-					Image:    "ghcr.io/snyk/sweater-comb:latest",
+					Image:    "snyk/sweater-comb:latest",
 					Original: "target-branch",
 				},
 			},

--- a/config/linter.go
+++ b/config/linter.go
@@ -4,7 +4,7 @@ import "fmt"
 
 const (
 	defaultSweaterCombImage = "gcr.io/snyk-main/sweater-comb:latest"
-	defaultOpticCIImage     = "ghcr.io/snyk/sweater-comb:latest"
+	defaultOpticCIImage     = "snyk/sweater-comb:latest"
 )
 
 var defaultSpectralExtraArgs = []string{"--format", "text"}


### PR DESCRIPTION
Fix comparison paths to work with the volume mounts used when Optic CI
is run as a Docker image.

Update the default Docker image used by the Optic CI linter to the
latest official release on Docker Hub,
https://hub.docker.com/r/snyk/sweater-comb.