### PR TITLE
fix: correct module paths so that v3 can be imported

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
   resource_class: small
   working_directory: ~/vervet
   docker:
-    - image: circleci/golang:1.16-node
+    - image: circleci/golang:1.17-node
 
 vu_metadata: &vu_metadata
     resource_class: small
@@ -52,7 +52,7 @@ jobs:
 
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.42.1
+      - image: golangci/golangci-lint:v1.43.0
     steps:
       - checkout
       - attach_workspace:

--- a/cmd/compiler.go
+++ b/cmd/compiler.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/snyk/vervet/config"
-	"github.com/snyk/vervet/internal/compiler"
+	"github.com/snyk/vervet/v3/config"
+	"github.com/snyk/vervet/v3/internal/compiler"
 )
 
 // Compile compiles versioned resources into versioned API specs.

--- a/cmd/compiler_test.go
+++ b/cmd/compiler_test.go
@@ -8,9 +8,9 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/getkin/kin-openapi/openapi3"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/cmd"
-	"github.com/snyk/vervet/testdata"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/cmd"
+	"github.com/snyk/vervet/v3/testdata"
 )
 
 func TestCompile(t *testing.T) {

--- a/cmd/localize.go
+++ b/cmd/localize.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/snyk/vervet"
+	"github.com/snyk/vervet/v3"
 )
 
 // Localize references and validate a single OpenAPI spec file

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/snyk/vervet"
+	"github.com/snyk/vervet/v3"
 )
 
 // Resolve aggregates, renders and validates resource specs at a particular

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/snyk/vervet/internal/scaffold"
+	"github.com/snyk/vervet/v3/internal/scaffold"
 )
 
 // ScaffoldInit creates a new project configuration from a provided scaffold directory.

--- a/cmd/scaffold_test.go
+++ b/cmd/scaffold_test.go
@@ -8,8 +8,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/snyk/vervet/cmd"
-	"github.com/snyk/vervet/testdata"
+	"github.com/snyk/vervet/v3/cmd"
+	"github.com/snyk/vervet/v3/testdata"
 )
 
 var vervetConfigFile = "./.vervet.yaml"

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,10 +11,10 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/config"
-	"github.com/snyk/vervet/internal/compiler"
-	"github.com/snyk/vervet/internal/generator"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/config"
+	"github.com/snyk/vervet/v3/internal/compiler"
+	"github.com/snyk/vervet/v3/internal/generator"
 )
 
 // VersionList is a command that lists all the versions of matching resources.

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -8,9 +8,9 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/cmd"
-	"github.com/snyk/vervet/testdata"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/cmd"
+	"github.com/snyk/vervet/v3/testdata"
 )
 
 func cd(c *qt.C, path string) {

--- a/cmd/vervet/main.go
+++ b/cmd/vervet/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/snyk/vervet/cmd"
+	"github.com/snyk/vervet/v3/cmd"
 )
 
 func main() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,7 +6,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/snyk/vervet/config"
+	"github.com/snyk/vervet/v3/config"
 )
 
 func TestLoad(t *testing.T) {

--- a/document_test.go
+++ b/document_test.go
@@ -6,8 +6,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/testdata"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/testdata"
 )
 
 func TestNewDocumentFile(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,34 +1,54 @@
-module github.com/snyk/vervet
+module github.com/snyk/vervet/v3
 
-go 1.16
+go 1.17
 
 require (
-	github.com/Microsoft/go-winio v0.5.1 // indirect
-	github.com/ProtonMail/go-crypto v0.0.0-20211112122917-428f8eabeeb3 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.0.2
-	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/frankban/quicktest v1.13.0
 	github.com/getkin/kin-openapi v0.87.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2
-	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.3.0
-	github.com/kevinburke/ssh_config v1.1.0 // indirect
-	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/manifoldco/promptui v0.9.0
-	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/urfave/cli/v2 v2.3.0
+	go.uber.org/multierr v1.7.0
+)
+
+require (
+	github.com/Microsoft/go-winio v0.5.1 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20211112122917-428f8eabeeb3 // indirect
+	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.3.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.15 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/kevinburke/ssh_config v1.1.0 // indirect
+	github.com/kr/pretty v0.2.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/multierr v1.7.0
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
 // Force git-go dependencies to use the latest go-crypto to resolve:

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/frankban/quicktest v1.13.0 h1:yNZif1OkDfNoDfb9zZa9aXIpejNR4F23Wely0c+Qdqk=
 github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/r/VLSOOIySU=
-github.com/getkin/kin-openapi v0.83.0 h1:qQbfSsapSPuRS73xhElJ85bWFo2REHNXBXAQ1kqqlCE=
-github.com/getkin/kin-openapi v0.83.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getkin/kin-openapi v0.87.0 h1:eeb0WBIgRiXra7ZY0Vo+jWloqvaF2kNEaxAyb+39N+E=
 github.com/getkin/kin-openapi v0.87.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -129,7 +127,6 @@ github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/X
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/xanzy/ssh-agent v0.3.1 h1:AmzO1SSWxw73zxFZPRwaMN1MohDw8UyHnmuxyceTEGo=
 github.com/xanzy/ssh-agent v0.3.1/go.mod h1:QIE4lCeL7nkC25x+yA3LBIYfwCc1TFziCtG7cBAac6w=
-go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
@@ -139,8 +136,6 @@ golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 h1:/pEO3GD/ABYAjuakUS6xSE
 golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 h1:DZshvxDdVoeKIbudAdFEKi+f70l51luSy/7b76ibTY0=
-golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f h1:hEYJvxw1lSnWIl8X9ofsYMklzaDs90JI2az5YMd4fPM=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -157,8 +152,6 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1 h1:kwrAHlwJ0DUBZwQ238v+Uod/3eZ8B2K5rYsUHBQvzmI=
-golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=

--- a/include_headers_test.go
+++ b/include_headers_test.go
@@ -6,8 +6,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/testdata"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/testdata"
 )
 
 func TestCommonResponseHeaders(t *testing.T) {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -15,13 +15,13 @@ import (
 	"github.com/ghodss/yaml"
 	"go.uber.org/multierr"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/config"
-	"github.com/snyk/vervet/internal/files"
-	"github.com/snyk/vervet/internal/linter"
-	"github.com/snyk/vervet/internal/linter/optic"
-	"github.com/snyk/vervet/internal/linter/spectral"
-	"github.com/snyk/vervet/internal/linter/sweatercomb"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/config"
+	"github.com/snyk/vervet/v3/internal/files"
+	"github.com/snyk/vervet/v3/internal/linter"
+	"github.com/snyk/vervet/v3/internal/linter/optic"
+	"github.com/snyk/vervet/v3/internal/linter/spectral"
+	"github.com/snyk/vervet/v3/internal/linter/sweatercomb"
 )
 
 // A Compiler checks and builds versioned API resource inputs into aggregated

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -10,10 +10,10 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/snyk/vervet/config"
-	"github.com/snyk/vervet/internal/files"
-	"github.com/snyk/vervet/internal/linter"
-	"github.com/snyk/vervet/testdata"
+	"github.com/snyk/vervet/v3/config"
+	"github.com/snyk/vervet/v3/internal/files"
+	"github.com/snyk/vervet/v3/internal/linter"
+	"github.com/snyk/vervet/v3/testdata"
 )
 
 func setup(c *qt.C) {

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/config"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/config"
 )
 
 // FileSource defines a source of spec files to lint. This abstraction allows

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/config"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/config"
 )
 
 // Generator generates files for new resources from data models and templates.

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -9,8 +9,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/snyk/vervet/config"
-	"github.com/snyk/vervet/testdata"
+	"github.com/snyk/vervet/v3/config"
+	"github.com/snyk/vervet/v3/testdata"
 )
 
 func setup(c *qt.C) {

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -3,7 +3,7 @@ package linter
 import (
 	"context"
 
-	"github.com/snyk/vervet/config"
+	"github.com/snyk/vervet/v3/config"
 )
 
 // A Linter checks that a set of spec files conform to some set of rules and

--- a/internal/linter/optic/git.go
+++ b/internal/linter/optic/git.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"go.uber.org/multierr"
 
-	"github.com/snyk/vervet/config"
+	"github.com/snyk/vervet/v3/config"
 )
 
 // gitRepoSource is a fileSource that resolves files out of a specific git

--- a/internal/linter/optic/linter.go
+++ b/internal/linter/optic/linter.go
@@ -20,10 +20,10 @@ import (
 	"github.com/ghodss/yaml"
 	"go.uber.org/multierr"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/config"
-	"github.com/snyk/vervet/internal/files"
-	"github.com/snyk/vervet/internal/linter"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/config"
+	"github.com/snyk/vervet/v3/internal/files"
+	"github.com/snyk/vervet/v3/internal/linter"
 )
 
 // Optic runs a Docker image containing Optic CI and built-in rules.

--- a/internal/linter/optic/linter_test.go
+++ b/internal/linter/optic/linter_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/google/uuid"
 
-	"github.com/snyk/vervet/config"
-	"github.com/snyk/vervet/internal/files"
-	"github.com/snyk/vervet/testdata"
+	"github.com/snyk/vervet/v3/config"
+	"github.com/snyk/vervet/v3/internal/files"
+	"github.com/snyk/vervet/v3/testdata"
 )
 
 func TestNewLocalFile(t *testing.T) {

--- a/internal/linter/spectral/linter.go
+++ b/internal/linter/spectral/linter.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	"github.com/snyk/vervet/config"
-	"github.com/snyk/vervet/internal/files"
-	"github.com/snyk/vervet/internal/linter"
+	"github.com/snyk/vervet/v3/config"
+	"github.com/snyk/vervet/v3/internal/files"
+	"github.com/snyk/vervet/v3/internal/linter"
 )
 
 // Spectral runs spectral on collections of files with a set of rules.

--- a/internal/linter/sweatercomb/linter.go
+++ b/internal/linter/sweatercomb/linter.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	"github.com/snyk/vervet/config"
-	"github.com/snyk/vervet/internal/files"
-	"github.com/snyk/vervet/internal/linter"
+	"github.com/snyk/vervet/v3/config"
+	"github.com/snyk/vervet/v3/internal/files"
+	"github.com/snyk/vervet/v3/internal/linter"
 )
 
 // SweaterComb runs a Docker image containing Spectral and some built-in rules,

--- a/internal/linter/sweatercomb/linter_test.go
+++ b/internal/linter/sweatercomb/linter_test.go
@@ -11,7 +11,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/snyk/vervet/config"
+	"github.com/snyk/vervet/v3/config"
 )
 
 func TestLinter(t *testing.T) {

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -7,8 +7,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/snyk/vervet/internal/scaffold"
-	"github.com/snyk/vervet/testdata"
+	"github.com/snyk/vervet/v3/internal/scaffold"
+	"github.com/snyk/vervet/v3/testdata"
 )
 
 func TestScaffold(t *testing.T) {

--- a/localizer_test.go
+++ b/localizer_test.go
@@ -8,8 +8,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/testdata"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/testdata"
 )
 
 func TestLocalize(t *testing.T) {

--- a/merge_test.go
+++ b/merge_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/testdata"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/testdata"
 )
 
 var openapiCmp = qt.CmpEquals(cmpopts.IgnoreUnexported(openapi3.Schema{}))

--- a/resource_test.go
+++ b/resource_test.go
@@ -7,8 +7,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	. "github.com/snyk/vervet"
-	"github.com/snyk/vervet/testdata"
+	. "github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/testdata"
 )
 
 func TestResource(t *testing.T) {

--- a/spec_test.go
+++ b/spec_test.go
@@ -6,8 +6,8 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/getkin/kin-openapi/openapi3"
 
-	. "github.com/snyk/vervet"
-	"github.com/snyk/vervet/testdata"
+	. "github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/testdata"
 )
 
 func TestSpecs(t *testing.T) {

--- a/testdata/embed_test.go
+++ b/testdata/embed_test.go
@@ -6,7 +6,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/getkin/kin-openapi/openapi3"
 
-	"github.com/snyk/vervet/testdata/output"
+	"github.com/snyk/vervet/v3/testdata/output"
 )
 
 func TestEmbedding(t *testing.T) {

--- a/util_test.go
+++ b/util_test.go
@@ -6,8 +6,8 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/ghodss/yaml"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/testdata"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/testdata"
 )
 
 func TestToSpecYAML(t *testing.T) {

--- a/version_test.go
+++ b/version_test.go
@@ -7,7 +7,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	. "github.com/snyk/vervet"
+	. "github.com/snyk/vervet/v3"
 )
 
 func TestParseVersion(t *testing.T) {

--- a/versionware/example/chi/example_test.go
+++ b/versionware/example/chi/example_test.go
@@ -15,14 +15,14 @@ import (
 	promware "github.com/slok/go-http-metrics/middleware"
 	promware_std "github.com/slok/go-http-metrics/middleware/std"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/versionware"
-	. "github.com/snyk/vervet/versionware/example"
-	"github.com/snyk/vervet/versionware/example/releases"
-	release_2021_11_01 "github.com/snyk/vervet/versionware/example/resources/things/2021-11-01"
-	release_2021_11_08 "github.com/snyk/vervet/versionware/example/resources/things/2021-11-08"
-	release_2021_11_20 "github.com/snyk/vervet/versionware/example/resources/things/2021-11-20"
-	"github.com/snyk/vervet/versionware/example/store"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/versionware"
+	. "github.com/snyk/vervet/v3/versionware/example"
+	"github.com/snyk/vervet/v3/versionware/example/releases"
+	release_2021_11_01 "github.com/snyk/vervet/v3/versionware/example/resources/things/2021-11-01"
+	release_2021_11_08 "github.com/snyk/vervet/v3/versionware/example/resources/things/2021-11-08"
+	release_2021_11_20 "github.com/snyk/vervet/v3/versionware/example/resources/things/2021-11-20"
+	"github.com/snyk/vervet/v3/versionware/example/store"
 )
 
 func Example() {

--- a/versionware/example/embed_test.go
+++ b/versionware/example/embed_test.go
@@ -5,8 +5,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/versionware/example/releases"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/versionware/example/releases"
 )
 
 func TestEmbedding(t *testing.T) {

--- a/versionware/example/go.mod
+++ b/versionware/example/go.mod
@@ -1,4 +1,4 @@
-module github.com/snyk/vervet/versionware/example
+module github.com/snyk/vervet/v3/versionware/example
 
 go 1.16
 
@@ -9,7 +9,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/slok/go-http-metrics v0.10.0
-	github.com/snyk/vervet v1.5.1
+	github.com/snyk/vervet/v3 v3.0.0-00010101000000-000000000000
 )
 
-replace github.com/snyk/vervet => ../..
+replace github.com/snyk/vervet/v3 => ../..

--- a/versionware/example/gorilla/example_test.go
+++ b/versionware/example/gorilla/example_test.go
@@ -13,14 +13,14 @@ import (
 	promware "github.com/slok/go-http-metrics/middleware"
 	promware_std "github.com/slok/go-http-metrics/middleware/std"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/versionware"
-	. "github.com/snyk/vervet/versionware/example"
-	"github.com/snyk/vervet/versionware/example/releases"
-	release_2021_11_01 "github.com/snyk/vervet/versionware/example/resources/things/2021-11-01"
-	release_2021_11_08 "github.com/snyk/vervet/versionware/example/resources/things/2021-11-08"
-	release_2021_11_20 "github.com/snyk/vervet/versionware/example/resources/things/2021-11-20"
-	"github.com/snyk/vervet/versionware/example/store"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/versionware"
+	. "github.com/snyk/vervet/v3/versionware/example"
+	"github.com/snyk/vervet/v3/versionware/example/releases"
+	release_2021_11_01 "github.com/snyk/vervet/v3/versionware/example/resources/things/2021-11-01"
+	release_2021_11_08 "github.com/snyk/vervet/v3/versionware/example/resources/things/2021-11-08"
+	release_2021_11_20 "github.com/snyk/vervet/v3/versionware/example/resources/things/2021-11-20"
+	"github.com/snyk/vervet/v3/versionware/example/store"
 )
 
 func Example() {

--- a/versionware/example/resources/things/2021-11-01/handlers.go
+++ b/versionware/example/resources/things/2021-11-01/handlers.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/versionware/example/resources/things"
-	"github.com/snyk/vervet/versionware/example/store"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/versionware/example/resources/things"
+	"github.com/snyk/vervet/v3/versionware/example/store"
 )
 
 // Version is the resource release version of handlers in this package.

--- a/versionware/example/resources/things/2021-11-08/handlers.go
+++ b/versionware/example/resources/things/2021-11-08/handlers.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/versionware/example/resources/things"
-	"github.com/snyk/vervet/versionware/example/store"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/versionware/example/resources/things"
+	"github.com/snyk/vervet/v3/versionware/example/store"
 )
 
 // Version is the resource release version of handlers in this package.

--- a/versionware/example/resources/things/2021-11-20/handlers.go
+++ b/versionware/example/resources/things/2021-11-20/handlers.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/versionware/example/store"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/versionware/example/store"
 )
 
 // Version is the resource release version of handlers in this package.

--- a/versionware/example/resources/things/types.go
+++ b/versionware/example/resources/things/types.go
@@ -4,7 +4,7 @@ package things
 import (
 	"time"
 
-	"github.com/snyk/vervet/versionware/example/store"
+	"github.com/snyk/vervet/v3/versionware/example/store"
 )
 
 // Attributes represents the data contents of a Thing resource.

--- a/versionware/handler.go
+++ b/versionware/handler.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"sort"
 
-	"github.com/snyk/vervet"
+	"github.com/snyk/vervet/v3"
 )
 
 const (

--- a/versionware/handler_test.go
+++ b/versionware/handler_test.go
@@ -9,8 +9,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/snyk/vervet"
-	"github.com/snyk/vervet/versionware"
+	"github.com/snyk/vervet/v3"
+	"github.com/snyk/vervet/v3/versionware"
 )
 
 func ExampleHandler() {

--- a/versionware/validator.go
+++ b/versionware/validator.go
@@ -9,7 +9,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/getkin/kin-openapi/routers/gorillamux"
 
-	"github.com/snyk/vervet"
+	"github.com/snyk/vervet/v3"
 )
 
 // Validator provides versioned OpenAPI validation middleware for HTTP requests

--- a/versionware/validator_test.go
+++ b/versionware/validator_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
 
-	"github.com/snyk/vervet/versionware"
+	"github.com/snyk/vervet/v3/versionware"
 )
 
 const (


### PR DESCRIPTION
A new major release version requires a module path update. This change
should allow other packages to import v3.

For more background on why this is needed, see:

* https://go.dev/doc/modules/release-workflow#breaking
* https://go.dev/doc/modules/major-version