### PR TITLE
fix: disallow requesting API version dates in the future

### DIFF
--- a/versionware/export_test.go
+++ b/versionware/export_test.go
@@ -1,3 +1,9 @@
 package versionware
 
+import "time"
+
 var DefaultValidatorConfig = defaultValidatorConfig
+
+func (v *Validator) SetToday(today func() time.Time) {
+	v.today = today
+}


### PR DESCRIPTION
Respond 400 when a version date is requested from the future.