### PR TITLE
fix: fail fast when creating a validator that has no specs.

### DIFF
--- a/versionware/validator.go
+++ b/versionware/validator.go
@@ -65,6 +65,9 @@ func today() time.Time {
 // requests according to the given OpenAPI spec versions. For configuration
 // defaults, a nil config may be used.
 func NewValidator(config *ValidatorConfig, docs ...*openapi3.T) (*Validator, error) {
+	if len(docs) == 0 {
+		return nil, fmt.Errorf("no OpenAPI versions provided")
+	}
 	if config == nil {
 		config = &defaultValidatorConfig
 	}


### PR DESCRIPTION
If an empty array of specs is passed to versionware.NewValidator, all
requests will 404. This is definitely not what callers will expect or
want.