### PR TITLE
feat: support macOS on M1

### DIFF
--- a/packaging/npm/package.json.in
+++ b/packaging/npm/package.json.in
@@ -7,10 +7,12 @@
   },
   "os": [
     "darwin",
-    "linux"
+    "linux",
+    "win32"
   ],
   "cpu": [
-    "x64"
+    "x64",
+    "arm64"
   ],
   "engines": {
     "node": ">=4.4.0"

--- a/scripts/dist.bash
+++ b/scripts/dist.bash
@@ -20,6 +20,7 @@ mkdir -p ./dist/bin
 for GOOS in linux darwin; do
     GOOS=$GOOS GOARCH=amd64 go build -a -o ./dist/bin/vervet-$GOOS-amd64 ./cmd/vervet
 done
+GOOS=darwin GOARCH=arm64 go build -a -o ./dist/bin/vervet-darwin-arm64 ./cmd/vervet
 GOOS=windows GOARCH=amd64 go build -a -o ./dist/bin/vervet.exe ./cmd/vervet
 
 cp packaging/npm/passthrough.js dist/bin/vervet


### PR DESCRIPTION
Add a darwin arm64 binary to the multi-arch NPM binary package.

$ file dist/bin/vervet-darwin-arm64
dist/bin/vervet-darwin-arm64: Mach-O 64-bit executable arm64

Fixes #134