### PR TITLE
fix: version list resource filtering

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -58,6 +58,9 @@ func VersionList(ctx *cli.Context) error {
 				if err != nil {
 					return err
 				}
+				if rcArg := ctx.Args().Get(1); rcArg != "" && rcArg != rc.Name {
+					continue
+				}
 				var pathNames []string
 				for k := range rc.Paths {
 					pathNames = append(pathNames, k)

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -84,6 +84,31 @@ func TestVersionList(t *testing.T) {
 `[1:])
 }
 
+func TestVersionListResource(t *testing.T) {
+	c := qt.New(t)
+	tmp := c.TempDir()
+	tmpFile := filepath.Join(tmp, "out")
+	c.Run("cmd", func(c *qt.C) {
+		output, err := os.Create(tmpFile)
+		c.Assert(err, qt.IsNil)
+		defer output.Close()
+		c.Patch(&os.Stdout, output)
+		cd(c, testdata.Path("."))
+		err = cmd.Vervet.Run([]string{"vervet", "version", "list", "testdata", "projects"})
+		c.Assert(err, qt.IsNil)
+	})
+	out, err := ioutil.ReadFile(tmpFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(out), qt.Equals, `
++----------+----------+-------------------------+--------------------------------------+--------+-------------------+
+|   API    | RESOURCE |         VERSION         |                 PATH                 | METHOD |     OPERATION     |
++----------+----------+-------------------------+--------------------------------------+--------+-------------------+
+| testdata | projects | 2021-06-04~experimental | /orgs/{orgId}/projects               | GET    | getOrgsProjects   |
+| testdata | projects | 2021-08-20~experimental | /orgs/{org_id}/projects/{project_id} | DELETE | deleteOrgsProject |
++----------+----------+-------------------------+--------------------------------------+--------+-------------------+
+`[1:])
+}
+
 func TestVersionNew(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
When running `vervet version list <api> <resource>`, endpoint versions
were not being filtered by the given resource, when given.