### PR TITLE
feat: support passing extra args, ci-context to optic-ci

### DIFF
--- a/config/linter.go
+++ b/config/linter.go
@@ -97,6 +97,17 @@ type OpticCILinter struct {
 
 	// Debug turns on debug logging.
 	Debug bool `json:"debug,omitempty"`
+
+	// CIContext specifies the location of an optional CI context JSON file to
+	// use when performing an optic-ci compare or bulk-compare. If this file is
+	// present when vervet lints, it will be passed to optic using the
+	// --ci-context option.
+	//
+	// See https://www.npmjs.com/package/@useoptic/api-checks#expected-contexts for more information.
+	CIContext string `json:"ciContext"`
+
+	// ExtraArgs may be used to pass extra arguments to `optic-ci`.
+	ExtraArgs []string `json:"extraArgs"`
 }
 
 func (l Linters) init() error {

--- a/versionware/example/go.mod
+++ b/versionware/example/go.mod
@@ -14,3 +14,6 @@ require (
 )
 
 replace github.com/snyk/vervet/v3 => ../..
+
+// TODO: remove once https://github.com/getkin/kin-openapi/pull/469 lands
+replace github.com/getkin/kin-openapi => github.com/cmars/kin-openapi v0.0.0-20220216164516-8ffc85653bfb

--- a/versionware/example/go.sum
+++ b/versionware/example/go.sum
@@ -63,6 +63,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cmars/kin-openapi v0.0.0-20220216164516-8ffc85653bfb h1:2Gx5x0oQWCtSfFwYV9I0RECvyc2x9N8aC2OUT0qDOnw=
+github.com/cmars/kin-openapi v0.0.0-20220216164516-8ffc85653bfb/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=


### PR DESCRIPTION
Add support for passing extra args to optic-ci, as well as setting
--ci-context if the file exists. This allows optic-ci to upload the API
comparison source and results to Optic Cloud when integration with the
SaaS is desired.

Drive-by: update versionware example go.mod, it needs the same
temporary replacement as introduced in #144 in order to build.