### PR TITLE
feat: adds vervet's version info to cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .idea
 .dccache
 .vscode
+/cmd/generate_version_init.go
 
 **/server
 config.json

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: lint test build
 
 .PHONY: build
 build:
-	go build -ldflags "-X 'github.com/snyk/vervet/cmd.VervetVersion=`git tag --sort=-version:refname | head -n 1`'" -a -o vervet ./cmd/vervet
+	go build -a -o vervet ./cmd/vervet
 
 # Run go mod tidy yourself
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: lint test build
 
 .PHONY: build
 build:
-	go build -a -o vervet ./cmd/vervet
+	go build -ldflags "-X 'github.com/snyk/vervet/cmd.VervetVersion=`git tag --sort=-version:refname | head -n 1`'" -a -o vervet ./cmd/vervet
 
 # Run go mod tidy yourself
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -15,6 +15,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// VervetVersion contains vervet's version, set by ldflags at build time:
+// go build -ldflags "-X 'github.com/snyk/vervet/cmd.VervetVersion=$VERSION'"
+var VervetVersion = "0.0.1"
+
 // VervetParams contains configuration parameters for the Vervet CLI application.
 type VervetParams struct {
 	Stdin  io.ReadCloser
@@ -67,6 +71,7 @@ func NewApp(vp VervetParams) *VervetApp {
 			Reader:    vp.Stdin,
 			Writer:    vp.Stdout,
 			ErrWriter: vp.Stderr,
+			Version:   VervetVersion,
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "debug",

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -15,9 +15,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// VervetVersion contains vervet's version, set by ldflags at build time:
-// go build -ldflags "-X 'github.com/snyk/vervet/cmd.VervetVersion=$VERSION'"
-var VervetVersion = "0.0.1"
+//go:generate ../scripts/genversion.bash
 
 // VervetParams contains configuration parameters for the Vervet CLI application.
 type VervetParams struct {
@@ -71,7 +69,7 @@ func NewApp(vp VervetParams) *VervetApp {
 			Reader:    vp.Stdin,
 			Writer:    vp.Stdout,
 			ErrWriter: vp.Stderr,
-			Version:   VervetVersion,
+			Version:   "develop", // Set in init created with go generate.
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "debug",

--- a/scripts/dist.bash
+++ b/scripts/dist.bash
@@ -17,6 +17,8 @@ rm -rf dist
 
 mkdir -p ./dist/bin
 
+go generate ./cmd/...
+
 for GOOS in linux darwin; do
     GOOS=$GOOS GOARCH=amd64 go build -a -o ./dist/bin/vervet-$GOOS-amd64 ./cmd/vervet
 done

--- a/scripts/genversion.bash
+++ b/scripts/genversion.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eux
+cd $(dirname $0)/..
+
+[ -n "${VERSION}" ]
+
+cat << EOF > cmd/generate_version_init.go
+// THIS IS A GENERATED FILE. DO NOT EDIT.
+
+package cmd
+
+func init() {
+    Vervet.App.Version = "${VERSION}"
+}
+EOF

--- a/scripts/release.bash
+++ b/scripts/release.bash
@@ -19,6 +19,9 @@ if [ -z $(git config user.email) ]; then
     git config user.email "vervet-ci@noreply.snyk.io"
     git config user.name "Vervet CI"
 fi
+
+go generate ./cmd/...
+
 git tag ${VERSION}
 git push -q https://${GH_TOKEN}@github.com/snyk/vervet.git --tags
 


### PR DESCRIPTION
urfave provides version info automatically as part of the cli app setup,
provided the cli is given "Version" as part of its setup.

This sets that field based on a global var in the `cmd` package, which can be
set via the ldflags arg at build time, e.g. to set the version based on git
tag as done in the Makefile.