### PR TITLE
fix: select correct architecture

### DIFF
--- a/packaging/npm/passthrough.js
+++ b/packaging/npm/passthrough.js
@@ -3,7 +3,7 @@ var path = require('path');
 
 // os and arch restrictions are handled by the package.json
 var os = process.platform;
-var arch = 'amd64';
+var arch = process.arch;
 
 // Select the right binary for this platform, then exec it with the original
 // arguments. This is a true exec(3), which will take over the pid, env, and

--- a/scripts/dist.bash
+++ b/scripts/dist.bash
@@ -20,9 +20,9 @@ mkdir -p ./dist/bin
 go generate ./cmd/...
 
 for GOOS in linux darwin; do
-    GOOS=$GOOS GOARCH=amd64 go build -a -o ./dist/bin/vervet-$GOOS-amd64 ./cmd/vervet
+    GOOS=$GOOS GOARCH=amd64 go build -a -o ./dist/bin/vervet-$GOOS-x64 ./cmd/vervet
+    GOOS=$GOOS GOARCH=arm64 go build -a -o ./dist/bin/vervet-$GOOS-arm64 ./cmd/vervet
 done
-GOOS=darwin GOARCH=arm64 go build -a -o ./dist/bin/vervet-darwin-arm64 ./cmd/vervet
 GOOS=windows GOARCH=amd64 go build -a -o ./dist/bin/vervet.exe ./cmd/vervet
 
 cp packaging/npm/passthrough.js dist/bin/vervet


### PR DESCRIPTION
* switch name of output binaries to match node arch convention

* add linux arm64 build

* use process.arch to select correct bin