### PR TITLE
feat: Make vervet.Version take in parameters by value

### DIFF
--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -23,7 +23,7 @@ func Resolve(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	specVersion, err := specVersions.At(*version)
+	specVersion, err := specVersions.At(version)
 	if err != nil {
 		return err
 	}

--- a/resource.go
+++ b/resource.go
@@ -120,7 +120,7 @@ func (e *ResourceVersions) At(vs string) (*Resource, error) {
 	}
 	for i := len(e.versions) - 1; i >= 0; i-- {
 		ev := e.versions[i].Version
-		if dateCmp, stabilityCmp := ev.compareDateStability(v); dateCmp <= 0 && stabilityCmp >= 0 {
+		if dateCmp, stabilityCmp := ev.compareDateStability(&v); dateCmp <= 0 && stabilityCmp >= 0 {
 			return e.versions[i], nil
 		}
 	}
@@ -131,7 +131,7 @@ type resourceVersionSlice []*Resource
 
 // Less implements sort.Interface.
 func (e resourceVersionSlice) Less(i, j int) bool {
-	return e[i].Version.Compare(&e[j].Version) < 0
+	return e[i].Version.Compare(e[j].Version) < 0
 }
 
 // Len implements sort.Interface.
@@ -292,7 +292,7 @@ func loadResource(specPath string, versionStr string) (*Resource, error) {
 		return nil, fmt.Errorf("failed to localize refs: %w", err)
 	}
 
-	ep := &Resource{Name: name, Document: doc, Version: *version}
+	ep := &Resource{Name: name, Document: doc, Version: version}
 	for path := range doc.T.Paths {
 		doc.T.Paths[path].ExtensionProps.Extensions[ExtSnykApiResource] = name
 	}

--- a/version_test.go
+++ b/version_test.go
@@ -268,7 +268,7 @@ func TestDeprecatedBy(t *testing.T) {
 	for i, test := range tests {
 		c.Logf("test#%d: %#v", i, test)
 		base, deprecatedBy := MustParseVersion(test.base), MustParseVersion(test.deprecatedBy)
-		c.Assert(base.DeprecatedBy(&deprecatedBy), qt.Equals, test.result)
+		c.Assert(base.DeprecatedBy(deprecatedBy), qt.Equals, test.result)
 	}
 }
 
@@ -313,7 +313,7 @@ func TestDeprecates(t *testing.T) {
 		deprecates, ok := versions.Deprecates(test.target)
 		c.Assert(ok, qt.Equals, test.isDeprecated)
 		if test.isDeprecated {
-			c.Assert(&test.deprecatedBy, qt.DeepEquals, deprecates)
+			c.Assert(test.deprecatedBy, qt.DeepEquals, deprecates)
 			sunset, ok := test.target.Sunset(deprecates)
 			c.Assert(ok, qt.IsTrue)
 			c.Assert(test.sunset, qt.Equals, sunset)

--- a/versionware/handler.go
+++ b/versionware/handler.go
@@ -96,7 +96,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		h.errFunc(w, req, http.StatusBadRequest, err)
 		return
 	}
-	resolved, handler, err := h.Resolve(*requested)
+	resolved, handler, err := h.Resolve(requested)
 	if err != nil {
 		h.errFunc(w, req, http.StatusNotFound, err)
 		return

--- a/versionware/validator.go
+++ b/versionware/validator.go
@@ -109,7 +109,7 @@ func NewValidator(config *ValidatorConfig, docs ...*openapi3.T) (*Validator, err
 		if err != nil {
 			return nil, err
 		}
-		v.versions[i] = *version
+		v.versions[i] = version
 		router, err := gorillamux.NewRouter(docs[i])
 		if err != nil {
 			return nil, err
@@ -146,7 +146,7 @@ func (v *Validator) Middleware(h http.Handler) http.Handler {
 				fmt.Errorf("requested version newer than present date %s", t))
 			return
 		}
-		resolvedIndex, err := v.versions.ResolveIndex(*requested)
+		resolvedIndex, err := v.versions.ResolveIndex(requested)
 		if err != nil {
 			v.errFunc(w, req, http.StatusNotFound, err)
 			return


### PR DESCRIPTION
My main goal with this PR is to permit chaining method calls on Version objects like:
```go
vstr := MustParseVersion("v1").AddDays(2).String()
```
This is currently not possible with some of the methods (e.g. `DateString`, `String`, `Add`, `Compare`, ...) because they are defined as pointer method.

`Version` is a relatively small structure composed of an `int`, an `int64`, a `uint64` and an address. Passing it by values, in similar way that it is done for `time.Time` seems appropriate (https://github.com/golang/go/blob/40e24a942bce7b10e23a7282e673ac8a758ca378/src/time/time.go#L248).

I took the PR a step further by updating the definition of `ParseVersion` to return a `Version` instead of a pointer to it. This is a breaking change that we may want to avoid. Looking for your inputs here. However, it brings the benefits of avoiding heap allocation and of harmonizing the `Version` API. 