### PR TITLE
feat: generator templates can reference their location

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -38,13 +38,13 @@ func TestVersionScope(t *testing.T) {
 	versionReadme := `
 version-readme:
   scope: version
-  filename: "` + out + `/{{.API}}/{{.Resource}}/{{.Version.DateString}}/README"
+  filename: "{{.Here}}/{{.API}}/{{.Resource}}/{{.Version.DateString}}/README"
   template: ".vervet/resource/version/README.tmpl"
 `
 	generatorsConf, err := config.LoadGenerators(bytes.NewBufferString(versionReadme))
 	c.Assert(err, qt.IsNil)
 
-	genReadme, err := New(generatorsConf["version-readme"], Debug(true))
+	genReadme, err := New(generatorsConf["version-readme"], Debug(true), Here(out))
 	c.Assert(err, qt.IsNil)
 
 	resources, err := MapResources(proj)
@@ -81,13 +81,13 @@ func TestResourceScope(t *testing.T) {
 	versionReadme := `
 resource-routes:
   scope: resource
-  filename: "` + out + `/{{ .API }}/{{ .Resource }}/routes.ts"
+  filename: "{{.Here}}/{{ .API }}/{{ .Resource }}/routes.ts"
   template: ".vervet/resource/routes.ts.tmpl"
 `
 	generatorsConf, err := config.LoadGenerators(bytes.NewBufferString(versionReadme))
 	c.Assert(err, qt.IsNil)
 
-	genReadme, err := New(generatorsConf["resource-routes"], Debug(true))
+	genReadme, err := New(generatorsConf["resource-routes"], Debug(true), Here(out))
 	c.Assert(err, qt.IsNil)
 
 	resources, err := MapResources(proj)

--- a/versionware/example/go.mod
+++ b/versionware/example/go.mod
@@ -1,4 +1,4 @@
-module github.com/snyk/vervet/v3/versionware/example
+module github.com/snyk/vervet/v4/versionware/example
 
 go 1.16
 
@@ -9,7 +9,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/slok/go-http-metrics v0.10.0
-	github.com/snyk/vervet/v3 v3.0.0-00010101000000-000000000000
+	github.com/snyk/vervet/v4 v4.0.0-00010101000000-000000000000
 )
 
-replace github.com/snyk/vervet/v3 => ../..
+replace github.com/snyk/vervet/v4 => ../..


### PR DESCRIPTION
Add a .Here field to scope in generator templates, so that generators
can reference files relative to where they are declared.

Drive-by: update versionware example to reference v4 properly