### PR TITLE
feat: optic-ci lint exceptions

### DIFF
--- a/config/linter.go
+++ b/config/linter.go
@@ -94,6 +94,14 @@ type OpticCILinter struct {
 	// CIContext exists.
 	UploadResults bool `json:"uploadResults"`
 
+	// Exceptions are files that are excluded from CI checks. This is an escape
+	// hatch of last resort, if a file needs to land and can't pass CI yet.
+	// They are specified as a mapping from project relative path to sha256
+	// sums of that spec file that is exempt. This makes the exception very
+	// narrow -- only a specific version of a specific file is skipped, after
+	// outside review and approval.
+	Exceptions map[string][]string
+
 	// ExtraArgs may be used to pass extra arguments to `optic-ci`.
 	ExtraArgs []string `json:"extraArgs"`
 }


### PR DESCRIPTION
Allow making very narrow exceptions for specs that do not pass optic-ci
lint rules as they currently are.

Exceptions are well, exceptional, but might need to be made to unblock
work that can't wait for rules to catch up. Exceptions are made based
on the spec file's relative path in the project, and its sha256. So any
subsequent change in the file will not fall under the exception.