### PR TITLE
feat: conflict-free component relocation during merge

### DIFF
--- a/deduplicate.go
+++ b/deduplicate.go
@@ -1,0 +1,169 @@
+package vervet
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// ComponentDeduplicator relocating name collisions in components across a
+// collection of OpenAPI documents, so that they can be non-destructively
+// merged.
+type ComponentDeduplicator struct {
+	contentDB   map[componentKey]string
+	docDB       map[componentKey]*openapi3.T
+	relocations map[componentKey]string
+}
+
+// NewComponentDeduplicator returns a new ComponentDeduplicator.
+func NewComponentDeduplicator() *ComponentDeduplicator {
+	return &ComponentDeduplicator{
+		contentDB: map[componentKey]string{},
+		docDB:     map[componentKey]*openapi3.T{},
+	}
+}
+
+type componentKey struct {
+	location string
+	ref      string
+}
+
+type componentKeys []componentKey
+
+func (ks componentKeys) Len() int { return len(ks) }
+func (ks componentKeys) Less(i, j int) bool {
+	if ks[i].location == ks[j].location {
+		return ks[i].ref < ks[j].ref
+	}
+	return ks[i].location < ks[j].location
+}
+func (ks componentKeys) Swap(i, j int) { ks[i], ks[j] = ks[j], ks[i] }
+
+func (dd *ComponentDeduplicator) Index(location string, doc *openapi3.T) error {
+	for name, value := range doc.Components.Schemas {
+		key := componentKey{location, "#/components/schemas/" + name}
+		digest, err := componentHash(value)
+		if err != nil {
+			return err
+		}
+		dd.contentDB[key] = digest
+		dd.docDB[key] = doc
+	}
+	for name, value := range doc.Components.Parameters {
+		key := componentKey{location, "#/components/parameters/" + name}
+		digest, err := componentHash(value)
+		if err != nil {
+			return err
+		}
+		dd.contentDB[key] = digest
+		dd.docDB[key] = doc
+	}
+	for name, value := range doc.Components.Headers {
+		key := componentKey{location, "#/components/headers/" + name}
+		digest, err := componentHash(value)
+		if err != nil {
+			return err
+		}
+		dd.contentDB[key] = digest
+		dd.docDB[key] = doc
+	}
+	for name, value := range doc.Components.RequestBodies {
+		key := componentKey{location, "#/components/requestBodies/" + name}
+		digest, err := componentHash(value)
+		if err != nil {
+			return err
+		}
+		dd.contentDB[key] = digest
+		dd.docDB[key] = doc
+	}
+	for name, value := range doc.Components.Responses {
+		key := componentKey{location, "#/components/responses/" + name}
+		digest, err := componentHash(value)
+		if err != nil {
+			return err
+		}
+		dd.contentDB[key] = digest
+		dd.docDB[key] = doc
+	}
+	for name, value := range doc.Components.SecuritySchemes {
+		key := componentKey{location, "#/components/securitySchemes/" + name}
+		digest, err := componentHash(value)
+		if err != nil {
+			return err
+		}
+		dd.contentDB[key] = digest
+		dd.docDB[key] = doc
+	}
+	for name, value := range doc.Components.Examples {
+		key := componentKey{location, "#/components/examples/" + name}
+		digest, err := componentHash(value)
+		if err != nil {
+			return err
+		}
+		dd.contentDB[key] = digest
+		dd.docDB[key] = doc
+	}
+	for name, value := range doc.Components.Links {
+		key := componentKey{location, "#/components/links/" + name}
+		digest, err := componentHash(value)
+		if err != nil {
+			return err
+		}
+		dd.contentDB[key] = digest
+		dd.docDB[key] = doc
+	}
+	for name, value := range doc.Components.Callbacks {
+		key := componentKey{location, "#/components/callbacks/" + name}
+		digest, err := componentHash(value)
+		if err != nil {
+			return err
+		}
+		dd.contentDB[key] = digest
+		dd.docDB[key] = doc
+	}
+	return nil
+}
+
+func componentHash(v interface{}) (string, error) {
+	h := sha256.New()
+	err := json.NewEncoder(h).Encode(&v)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func (dd *ComponentDeduplicator) Deduplicate() error {
+	dd.calculateRelocations()
+	fmt.Println(dd.relocations)
+	return nil
+}
+
+func (dd *ComponentDeduplicator) calculateRelocations() {
+	var keys componentKeys
+	for k := range dd.contentDB {
+		keys = append(keys, k)
+	}
+	sort.Sort(keys)
+
+	dd.relocations = map[componentKey]string{}
+
+	dedup := map[string]string{}
+	relocatedDigests := map[string]string{}
+	for _, key := range keys {
+		digest := dd.contentDB[key]
+		if relocatedRef, ok := relocatedDigests[digest]; ok {
+			dd.relocations[key] = relocatedRef
+		} else if priorDigest, ok := dedup[key.ref]; ok && digest != priorDigest {
+			relocatedRef := key.ref + "$" + digest // TODO: shorten this
+			relocatedDigests[digest] = relocatedRef
+			dd.relocations[key] = relocatedRef
+		} else {
+			dedup[key.ref] = digest
+		}
+	}
+}

--- a/merge.go
+++ b/merge.go
@@ -6,14 +6,12 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// Merge adds the paths and components from a source OpenAPI document root,
-// to a destination document root.
+// Merge adds the paths and components from a source OpenAPI document root, to
+// a destination document root. When replace is true, conflicting components or
+// paths in dst will be overwritten by those in src. When replace is false,
+// conflicts will panic.
 //
-// TODO: This is a naive implementation that should be improved to detect and
-// resolve conflicts better. For example, distinct resources might have
-// localized references with the same URIs but different content.
-// Content-addressible resource versions may further facilitate governance;
-// this also would facilitate detecting and relocating such conflicts.
+// This function is deprecated and MergeRelocate should be used instead.
 func Merge(dst, src *openapi3.T, replace bool) {
 	mergeComponents(dst, src, replace)
 	mergeInfo(dst, src, replace)
@@ -129,7 +127,7 @@ func mergeInfo(dst, src *openapi3.T, replace bool) {
 	}
 }
 
-func mergePaths(dst, src *openapi3.T, replace bool) {
+func mergePaths(dst, src *openapi3.T, replace bool) error {
 	if src.Paths != nil && dst.Paths == nil {
 		dst.Paths = make(openapi3.Paths)
 	}
@@ -138,6 +136,7 @@ func mergePaths(dst, src *openapi3.T, replace bool) {
 			dst.Paths[k] = v
 		}
 	}
+	return nil
 }
 
 func mergeSecurityRequirements(dst, src *openapi3.T, replace bool) {

--- a/ref_alias_resolver.go
+++ b/ref_alias_resolver.go
@@ -40,9 +40,9 @@ func newRefAliasResolver(doc *openapi3.T) (*refAliasResolver, error) {
 	return &refAliasResolver{doc: doc, refAliases: refAliases}, nil
 }
 
-func (l *refAliasResolver) resolveRefAlias(ref string) string {
+func (r *refAliasResolver) resolveRefAlias(ref string) string {
 	if ref != "" && ref[0] == '#' {
-		for refAlias, refTarget := range l.refAliases {
+		for refAlias, refTarget := range r.refAliases {
 			if strings.HasPrefix(ref, refAlias) {
 				return strings.Replace(ref, refAlias, refTarget+"#", 1)
 			}
@@ -52,26 +52,26 @@ func (l *refAliasResolver) resolveRefAlias(ref string) string {
 }
 
 // resolve rewrites all references in the OpenAPI document to local references.
-func (l *refAliasResolver) resolve() error {
-	return reflectwalk.Walk(l.doc, l)
+func (r *refAliasResolver) resolve() error {
+	return reflectwalk.Walk(r.doc, r)
 }
 
 // Struct implements reflectwalk.StructWalker
-func (l *refAliasResolver) Struct(v reflect.Value) error {
-	l.curRefType, l.curRefField = v, v.FieldByName("Ref")
+func (r *refAliasResolver) Struct(v reflect.Value) error {
+	r.curRefType, r.curRefField = v, v.FieldByName("Ref")
 	return nil
 }
 
 // StructField implements reflectwalk.StructWalker
-func (l *refAliasResolver) StructField(sf reflect.StructField, v reflect.Value) error {
-	if !l.curRefField.IsValid() {
+func (r *refAliasResolver) StructField(sf reflect.StructField, v reflect.Value) error {
+	if !r.curRefField.IsValid() {
 		return nil
 	}
-	ref := l.curRefField.String()
+	ref := r.curRefField.String()
 	if ref == "" {
 		return nil
 	}
-	ref = l.resolveRefAlias(ref)
-	l.curRefField.Set(reflect.ValueOf(ref))
+	ref = r.resolveRefAlias(ref)
+	r.curRefField.Set(reflect.ValueOf(ref))
 	return nil
 }

--- a/ref_relocator.go
+++ b/ref_relocator.go
@@ -1,0 +1,43 @@
+package vervet
+
+/*
+func replaceRefs(doc *openapi3.T, targetRef, suffix string) error {
+	r := &refReplacer{targetRef: targetRef, suffix: suffix}
+	err := r.replace(doc)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// refReplacer replaces references in a self-contained OpenAPI document object.
+type refReplacer struct {
+	targetRef string
+	suffix    string
+
+	curRefType  reflect.Value
+	curRefField reflect.Value
+}
+
+func (r *refReplacer) replace(doc *openapi3.T) error {
+	return reflectwalk.Walk(doc, r)
+}
+
+// Struct implements reflectwalk.StructWalker
+func (r *refReplacer) Struct(v reflect.Value) error {
+	r.curRefType, r.curRefField = v, v.FieldByName("Ref")
+	return nil
+}
+
+// StructField implements reflectwalk.StructWalker
+func (r *refReplacer) StructField(sf reflect.StructField, v reflect.Value) error {
+	if !r.curRefField.IsValid() {
+		return nil
+	}
+	ref := r.curRefField.String()
+	if ref == r.oldRef {
+		r.curRefField.Set(reflect.ValueOf(r.newRef))
+	}
+	return nil
+}
+*/

--- a/resource.go
+++ b/resource.go
@@ -299,6 +299,7 @@ func loadResource(specPath string, versionStr string) (*ResourceVersion, error) 
 	for path := range doc.T.Paths {
 		doc.T.Paths[path].ExtensionProps.Extensions[ExtSnykApiResource] = name
 	}
+	doc.T.ExtensionProps.Extensions[ExtSnykApiVersion] = version.String()
 	return ep, nil
 }
 

--- a/resource_test.go
+++ b/resource_test.go
@@ -92,12 +92,14 @@ func TestIsExtensionNotFound(t *testing.T) {
 	resource, err := eps.At("2021-06-04~experimental")
 	c.Assert(err, qt.IsNil)
 
-	_, err = ExtensionString(resource.ExtensionProps, ExtSnykApiVersion)
-	c.Assert(IsExtensionNotFound(err), qt.IsTrue)
-
 	_, err = ExtensionString(resource.ExtensionProps, "some-bogus-value")
 	c.Assert(IsExtensionNotFound(err), qt.IsTrue)
 
+	// Resource specs are annotated with the version on load.
+	_, err = ExtensionString(resource.ExtensionProps, ExtSnykApiVersion)
+	c.Assert(IsExtensionNotFound(err), qt.IsFalse)
+
+	// Resource specs are annotated with the stability on load.
 	_, err = ExtensionString(resource.ExtensionProps, ExtSnykApiStability)
 	c.Assert(IsExtensionNotFound(err), qt.IsFalse)
 }

--- a/resource_versions.go
+++ b/resource_versions.go
@@ -46,6 +46,24 @@ func (s resourceVersionsSlice) versions() VersionSlice {
 }
 
 func (s resourceVersionsSlice) at(v Version) (*openapi3.T, error) {
+	dd := NewComponentDeduplicator()
+	for _, eps := range s {
+		ep, err := eps.At(v.String())
+		if err == ErrNoMatchingVersion {
+			continue
+		} else if err != nil {
+			return nil, err
+		}
+		err = dd.Index(ep.path, ep.T)
+		if err != nil {
+			return nil, err
+		}
+	}
+	err := dd.Deduplicate()
+	if err != nil {
+		return nil, err
+	}
+
 	var result *openapi3.T
 	for _, eps := range s {
 		ep, err := eps.At(v.String())


### PR DESCRIPTION
When merging OpenAPI documents, detect colliding component definitions
and relocate them to non-conflicting component names, updating
references accordingly.

This "scopes" component references to the original version spec in which
they were originally referenced.

[WIP: still working through some test cases, issues with overlays]