### PR TITLE
fix: tag conflicts, error reporting in collator

### DIFF
--- a/internal/cmd/compiler_test.go
+++ b/internal/cmd/compiler_test.go
@@ -99,4 +99,5 @@ func TestBuildConflictComponents(t *testing.T) {
 	c.Assert(err.Error(), qt.Contains, `failed to load spec versions: the following errors occurred:`)
 	c.Assert(err.Error(), qt.Contains, "\n -  conflict in #/components/parameters/Version:")
 	c.Assert(err.Error(), qt.Contains, "\n -  conflict in #/components/responses/400:")
+	c.Assert(err.Error(), qt.Contains, "\n -  conflict in #/tags Something:")
 }

--- a/internal/linter/optic/linter_test.go
+++ b/internal/linter/optic/linter_test.go
@@ -99,7 +99,7 @@ func TestLocalException(t *testing.T) {
 		file, hash, result string
 	}{{
 		file:   "hello/2021-06-01/spec.yaml",
-		hash:   "71618dbb1452852b6fc277ff4e0ccd376f4ce8961deb9887d32a57e44e556ef9",
+		hash:   "c904dc0c42de4f84036f006dc245f05e08071f7616ed2d60f1d0f528859bca0a",
 		result: "{}",
 	}, {
 		file:   "hello/2021-06-01/spec.yaml",

--- a/testdata/conflict-components/_examples/2021-06-01/spec.yaml
+++ b/testdata/conflict-components/_examples/2021-06-01/spec.yaml
@@ -6,6 +6,9 @@ info:
 servers:
   - url: /api/v3
     description: Snyk Registry
+tags:
+  - name: Something
+    description: Something
 paths:
   /examples/hello-world/{id}:
     get:

--- a/testdata/conflict-components/projects/2021-06-04/spec.yaml
+++ b/testdata/conflict-components/projects/2021-06-04/spec.yaml
@@ -6,6 +6,9 @@ info:
 servers:
   - url: /api/v3
     description: Snyk Registry
+tags:
+  - name: Something
+    description: Something Else
 components:
   x-somewhere-else:
     $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.6.0/components/common.yaml'

--- a/testdata/output/2021-06-01~experimental/spec.json
+++ b/testdata/output/2021-06-01~experimental/spec.json
@@ -654,5 +654,11 @@
       "url": "https://example.com/api/v3"
     }
   ],
+  "tags": [
+    {
+      "description": "Something",
+      "name": "Something"
+    }
+  ],
   "x-snyk-api-version": "2021-06-01~experimental"
 }

--- a/testdata/output/2021-06-01~experimental/spec.yaml
+++ b/testdata/output/2021-06-01~experimental/spec.yaml
@@ -456,4 +456,7 @@ paths:
 servers:
 - description: Test API v3
   url: https://example.com/api/v3
+tags:
+- description: Something
+  name: Something
 x-snyk-api-version: 2021-06-01~experimental

--- a/testdata/output/2021-06-04~experimental/spec.json
+++ b/testdata/output/2021-06-04~experimental/spec.json
@@ -874,6 +874,9 @@
             "$ref": "#/components/responses/500"
           }
         },
+        "tags": [
+          "Projects"
+        ],
         "x-snyk-api-releases": [
           "2021-06-04~experimental"
         ],
@@ -886,6 +889,16 @@
     {
       "description": "Test API v3",
       "url": "https://example.com/api/v3"
+    }
+  ],
+  "tags": [
+    {
+      "description": "Projects",
+      "name": "Projects"
+    },
+    {
+      "description": "Something",
+      "name": "Something"
     }
   ],
   "x-snyk-api-version": "2021-06-04~experimental"

--- a/testdata/output/2021-06-04~experimental/spec.yaml
+++ b/testdata/output/2021-06-04~experimental/spec.yaml
@@ -613,6 +613,8 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+      tags:
+      - Projects
       x-snyk-api-releases:
       - 2021-06-04~experimental
       x-snyk-api-version: 2021-06-04~experimental
@@ -620,4 +622,9 @@ paths:
 servers:
 - description: Test API v3
   url: https://example.com/api/v3
+tags:
+- description: Projects
+  name: Projects
+- description: Something
+  name: Something
 x-snyk-api-version: 2021-06-04~experimental

--- a/testdata/output/2021-06-07~experimental/spec.json
+++ b/testdata/output/2021-06-07~experimental/spec.json
@@ -874,6 +874,9 @@
             "$ref": "#/components/responses/500"
           }
         },
+        "tags": [
+          "Projects"
+        ],
         "x-snyk-api-releases": [
           "2021-06-04~experimental"
         ],
@@ -886,6 +889,12 @@
     {
       "description": "Test API v3",
       "url": "https://example.com/api/v3"
+    }
+  ],
+  "tags": [
+    {
+      "description": "Projects",
+      "name": "Projects"
     }
   ],
   "x-snyk-api-version": "2021-06-07~experimental"

--- a/testdata/output/2021-06-07~experimental/spec.yaml
+++ b/testdata/output/2021-06-07~experimental/spec.yaml
@@ -613,6 +613,8 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+      tags:
+      - Projects
       x-snyk-api-releases:
       - 2021-06-04~experimental
       x-snyk-api-version: 2021-06-04~experimental
@@ -620,4 +622,7 @@ paths:
 servers:
 - description: Test API v3
   url: https://example.com/api/v3
+tags:
+- description: Projects
+  name: Projects
 x-snyk-api-version: 2021-06-07~experimental

--- a/testdata/output/2021-06-13~beta/spec.json
+++ b/testdata/output/2021-06-13~beta/spec.json
@@ -762,5 +762,11 @@
       "url": "https://example.com/api/v3"
     }
   ],
+  "tags": [
+    {
+      "description": "Something",
+      "name": "Something"
+    }
+  ],
   "x-snyk-api-version": "2021-06-13~beta"
 }

--- a/testdata/output/2021-06-13~beta/spec.yaml
+++ b/testdata/output/2021-06-13~beta/spec.yaml
@@ -527,4 +527,7 @@ paths:
 servers:
 - description: Test API v3
   url: https://example.com/api/v3
+tags:
+- description: Something
+  name: Something
 x-snyk-api-version: 2021-06-13~beta

--- a/testdata/output/2021-06-13~experimental/spec.json
+++ b/testdata/output/2021-06-13~experimental/spec.json
@@ -982,6 +982,9 @@
             "$ref": "#/components/responses/500"
           }
         },
+        "tags": [
+          "Projects"
+        ],
         "x-snyk-api-releases": [
           "2021-06-04~experimental"
         ],
@@ -994,6 +997,16 @@
     {
       "description": "Test API v3",
       "url": "https://example.com/api/v3"
+    }
+  ],
+  "tags": [
+    {
+      "description": "Projects",
+      "name": "Projects"
+    },
+    {
+      "description": "Something",
+      "name": "Something"
     }
   ],
   "x-snyk-api-version": "2021-06-13~experimental"

--- a/testdata/output/2021-06-13~experimental/spec.yaml
+++ b/testdata/output/2021-06-13~experimental/spec.yaml
@@ -684,6 +684,8 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+      tags:
+      - Projects
       x-snyk-api-releases:
       - 2021-06-04~experimental
       x-snyk-api-version: 2021-06-04~experimental
@@ -691,4 +693,9 @@ paths:
 servers:
 - description: Test API v3
   url: https://example.com/api/v3
+tags:
+- description: Projects
+  name: Projects
+- description: Something
+  name: Something
 x-snyk-api-version: 2021-06-13~experimental

--- a/testdata/output/2021-08-20~beta/spec.json
+++ b/testdata/output/2021-08-20~beta/spec.json
@@ -762,5 +762,11 @@
       "url": "https://example.com/api/v3"
     }
   ],
+  "tags": [
+    {
+      "description": "Something",
+      "name": "Something"
+    }
+  ],
   "x-snyk-api-version": "2021-08-20~beta"
 }

--- a/testdata/output/2021-08-20~beta/spec.yaml
+++ b/testdata/output/2021-08-20~beta/spec.yaml
@@ -527,4 +527,7 @@ paths:
 servers:
 - description: Test API v3
   url: https://example.com/api/v3
+tags:
+- description: Something
+  name: Something
 x-snyk-api-version: 2021-08-20~beta

--- a/testdata/output/2021-08-20~experimental/spec.json
+++ b/testdata/output/2021-08-20~experimental/spec.json
@@ -982,6 +982,9 @@
             "$ref": "#/components/responses/500"
           }
         },
+        "tags": [
+          "Projects"
+        ],
         "x-snyk-api-releases": [
           "2021-06-04~experimental"
         ],
@@ -1044,6 +1047,9 @@
             "$ref": "#/components/responses/500"
           }
         },
+        "tags": [
+          "Projects"
+        ],
         "x-snyk-api-releases": [
           "2021-08-20~experimental"
         ],
@@ -1056,6 +1062,16 @@
     {
       "description": "Test API v3",
       "url": "https://example.com/api/v3"
+    }
+  ],
+  "tags": [
+    {
+      "description": "Projects",
+      "name": "Projects"
+    },
+    {
+      "description": "Something",
+      "name": "Something"
     }
   ],
   "x-snyk-api-version": "2021-08-20~experimental"

--- a/testdata/output/2021-08-20~experimental/spec.yaml
+++ b/testdata/output/2021-08-20~experimental/spec.yaml
@@ -635,6 +635,8 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+      tags:
+      - Projects
       x-snyk-api-releases:
       - 2021-08-20~experimental
       x-snyk-api-version: 2021-08-20~experimental
@@ -724,6 +726,8 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+      tags:
+      - Projects
       x-snyk-api-releases:
       - 2021-06-04~experimental
       x-snyk-api-version: 2021-06-04~experimental
@@ -731,4 +735,9 @@ paths:
 servers:
 - description: Test API v3
   url: https://example.com/api/v3
+tags:
+- description: Projects
+  name: Projects
+- description: Something
+  name: Something
 x-snyk-api-version: 2021-08-20~experimental

--- a/testdata/resources/_examples/hello-world/2021-06-01/spec.yaml
+++ b/testdata/resources/_examples/hello-world/2021-06-01/spec.yaml
@@ -6,6 +6,9 @@ info:
 servers:
   - url: /api/v3
     description: Snyk Registry
+tags:
+  - name: Something
+    description: Something
 paths:
   /examples/hello-world/{id}:
     get:

--- a/testdata/resources/_examples/hello-world/2021-06-13/spec.yaml
+++ b/testdata/resources/_examples/hello-world/2021-06-13/spec.yaml
@@ -6,6 +6,9 @@ info:
 servers:
   - url: /api/v3
     description: Snyk Registry
+tags:
+  - name: Something
+    description: Something
 paths:
   /examples/hello-world:
     post:

--- a/testdata/resources/projects/2021-06-04/spec.yaml
+++ b/testdata/resources/projects/2021-06-04/spec.yaml
@@ -9,9 +9,13 @@ servers:
 components:
   x-somewhere-else:
     $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.6.0/components/common.yaml'
+tags:
+  - name: Projects
+    description: Projects
 paths:
   /orgs/{orgId}/projects:
     get:
+      tags: ["Projects"]
       description: Get a list of an organization's projects.
       operationId: getOrgsProjects
       parameters:

--- a/testdata/resources/projects/2021-08-20/spec.yaml
+++ b/testdata/resources/projects/2021-08-20/spec.yaml
@@ -6,9 +6,15 @@ info:
 servers:
   - url: /api/v3
     description: Snyk Registry
+tags:
+  - name: Projects
+    description: Projects
+  - name: Something
+    description: Something
 paths:
   /orgs/{org_id}/projects/{project_id}:
     delete:
+      tags: ["Projects"]
       description: Delete an organization's project.
       operationId: deleteOrgsProject
       parameters:


### PR DESCRIPTION
Tags should be allowed to be duplicated among resource versions and
specs -- this is how multiple operations share a tag. This change allows
that to happen.

Tag conflict errors are returned when tags having the same name have
a different description or extensions. This prevents one resource
version from mysteriously overwriting that of another. The conflicting
files are referenced clearly in the error message.

Finally, all conflict errors found in the entire collate process are
returned. This avoids a "pulling teeth" interaction where the user fixes
one problem just to find the next one.