### PR TITLE
fix: clean references when collating resources into single version

### DIFF
--- a/collator.go
+++ b/collator.go
@@ -39,7 +39,13 @@ func (c *Collator) Collate(rv *ResourceVersion) error {
 	if c.result == nil {
 		c.result = &openapi3.T{}
 	}
-	err := c.mergeComponents(rv)
+
+	err := rv.cleanRefs()
+	if err != nil {
+		return err
+	}
+
+	err = c.mergeComponents(rv)
 	if err != nil {
 		errs = multierr.Append(errs, err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/dop251/goja v0.0.0-20220214123719-b09a6bfa842f
 	github.com/frankban/quicktest v1.13.0
-	github.com/getkin/kin-openapi v0.92.0
+	github.com/getkin/kin-openapi v0.93.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/google/go-cmp v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/getkin/kin-openapi v0.90.0 h1:k0MeVmRSdKDjqJbyYghK3GkVL59s6bow46s2rNL
 github.com/getkin/kin-openapi v0.90.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getkin/kin-openapi v0.92.0 h1:lR1imqtGufk9Iv5dQoGwWbBP2SMcwI2ndIydSqwUyBI=
 github.com/getkin/kin-openapi v0.92.0/go.mod h1:LWZfzOd7PRy8GJ1dJ6mCU6tNdSfOwRac1BUPam4aw6Q=
+github.com/getkin/kin-openapi v0.93.0 h1:fc9z+9VADQla6bEb7V+dtZmr9Gj4qB6ZsD8c3pqEK0E=
+github.com/getkin/kin-openapi v0.93.0/go.mod h1:LWZfzOd7PRy8GJ1dJ6mCU6tNdSfOwRac1BUPam4aw6Q=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=

--- a/resource.go
+++ b/resource.go
@@ -83,6 +83,22 @@ func (e *ResourceVersion) Validate(ctx context.Context) error {
 	return nil
 }
 
+// cleanRefs removes any shared pointer references that might exist between
+// this resource version document and any others.
+func (rv *ResourceVersion) cleanRefs() error {
+	buf, err := json.Marshal(rv.Document.T)
+	if err != nil {
+		return err
+	}
+	var doc openapi3.T
+	err = json.Unmarshal(buf, &doc)
+	if err != nil {
+		return err
+	}
+	rv.T = &doc
+	return nil
+}
+
 // ResourceVersions defines a collection of multiple versions of a resource.
 type ResourceVersions struct {
 	versions resourceVersionSlice

--- a/versionware/example/go.mod
+++ b/versionware/example/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/frankban/quicktest v1.13.0
-	github.com/getkin/kin-openapi v0.92.0
+	github.com/getkin/kin-openapi v0.93.0
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/gorilla/mux v1.8.0
 	github.com/prometheus/client_golang v1.11.0

--- a/versionware/example/go.sum
+++ b/versionware/example/go.sum
@@ -86,6 +86,8 @@ github.com/getkin/kin-openapi v0.90.0 h1:k0MeVmRSdKDjqJbyYghK3GkVL59s6bow46s2rNL
 github.com/getkin/kin-openapi v0.90.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getkin/kin-openapi v0.92.0 h1:lR1imqtGufk9Iv5dQoGwWbBP2SMcwI2ndIydSqwUyBI=
 github.com/getkin/kin-openapi v0.92.0/go.mod h1:LWZfzOd7PRy8GJ1dJ6mCU6tNdSfOwRac1BUPam4aw6Q=
+github.com/getkin/kin-openapi v0.93.0 h1:fc9z+9VADQla6bEb7V+dtZmr9Gj4qB6ZsD8c3pqEK0E=
+github.com/getkin/kin-openapi v0.93.0/go.mod h1:LWZfzOd7PRy8GJ1dJ6mCU6tNdSfOwRac1BUPam4aw6Q=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=


### PR DESCRIPTION
When collating multiple resource version docs into a single OpenAPI for
the entire service at that version, I found it necessary to reparse the
document to get a "clean" document structure -- otherwise the openapi3.T
"hangs" on to references and thinks it contains components that it
doesn't.