### PR TITLE
fix: goreleaser pin at 1.6.3

### DIFF
--- a/scripts/release.bash
+++ b/scripts/release.bash
@@ -34,5 +34,5 @@ fi
 # Github release
 # Do this last; if it fails, it's easy to create a release in the UI.
 # Pushing the tags and publishing to NPM are more important.
-go install github.com/goreleaser/goreleaser@latest
+go install github.com/goreleaser/goreleaser@1.6.3
 GITHUB_TOKEN=${GH_TOKEN} goreleaser release --rm-dist


### PR DESCRIPTION
goreleaser 1.7.0 only builds and installs with Go 1.18, and we're still
on 1.17.