### PR TITLE
fix: goreleaser version typo

### DIFF
--- a/scripts/release.bash
+++ b/scripts/release.bash
@@ -34,5 +34,5 @@ fi
 # Github release
 # Do this last; if it fails, it's easy to create a release in the UI.
 # Pushing the tags and publishing to NPM are more important.
-go install github.com/goreleaser/goreleaser@1.6.3
+go install github.com/goreleaser/goreleaser@v1.6.3
 GITHUB_TOKEN=${GH_TOKEN} goreleaser release --rm-dist


### PR DESCRIPTION
Tag is `v1.6.3` (https://github.com/goreleaser/goreleaser/releases/tag/v1.6.3)