### PR TITLE
feat: support for multiple duplicate build output paths per API

### DIFF
--- a/config/api.go
+++ b/config/api.go
@@ -70,8 +70,9 @@ type Overlay struct {
 // Output defines where the aggregate versioned OpenAPI specs should be created
 // during compilation.
 type Output struct {
-	Path   string `json:"path"`
-	Linter string `json:"linter"`
+	Path   string   `json:"path,omitempty"`
+	Paths  []string `json:"paths,omitempty"`
+	Linter string   `json:"linter"`
 }
 
 func (a APIs) init(p *Project) error {
@@ -108,7 +109,11 @@ func (a APIs) init(p *Project) error {
 				}
 			}
 		}
-		if api.Output != nil && api.Output.Linter != "" {
+		if api.Output != nil {
+			if len(api.Output.Paths) > 0 && api.Output.Path != "" {
+				return fmt.Errorf("output should specify one of 'path' or 'paths', not both (apis.%s.output)",
+					api.Name)
+			}
 			if api.Output.Linter != "" {
 				if linter, ok := p.Linters[api.Output.Linter]; !ok {
 					return fmt.Errorf("linter %q not found (apis.%s.output.linter)",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -220,6 +220,25 @@ apis:
 		err: `optic linter does not yet support compiled specs \(apis\.testapi\.output\.linter\)`,
 	}, {
 		conf: `
+version: "1"
+linters:
+  ci:
+    optic-ci: {}
+apis:
+  testapi:
+    resources:
+      - path: resources
+        linter: ci
+    output:
+      path: /somewhere/else
+      paths:
+        - /another/place
+        - /and/another
+      linter: ci
+`[1:],
+		err: `output should specify one of 'path' or 'paths', not both \(apis\.testapi\.output\)`,
+	}, {
+		conf: `
 linters:
   ci:
 `[1:],

--- a/internal/cmd/compiler_test.go
+++ b/internal/cmd/compiler_test.go
@@ -76,8 +76,8 @@ func TestBuildInclude(t *testing.T) {
 		// testdata/.vervet.yaml contains an overlay that modifies the servers:
 		// section. This patches the output to match expected.
 		doc.Servers = []*openapi3.Server{{
-			Description: "Test API v3",
-			URL:         "https://example.com/api/v3",
+			Description: "Test REST API",
+			URL:         "https://example.com/api/rest",
 		}}
 
 		c.Assert(expected, qt.JSONEquals, doc)

--- a/internal/files/copy.go
+++ b/internal/files/copy.go
@@ -1,0 +1,70 @@
+package files
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// CopyItem copies a file or directory from src to dst.
+func CopyItem(dst, src string, force bool) error {
+	if st, err := os.Stat(src); err == nil && st.IsDir() {
+		return CopyDir(dst, src, force)
+	} else if err == nil {
+		return CopyFile(dst, src, force)
+	} else {
+		return err
+	}
+}
+
+// CopyDir recursively copies a directory from src to dst.
+func CopyDir(dst, src string, force bool) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		name, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		return CopyFile(filepath.Join(dst, name), path, force)
+	})
+}
+
+// CopyFile copies a file from src to dst. If there are missing directories in
+// dst, they are created.
+func CopyFile(dst, src string, force bool) error {
+	srcf, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcf.Close()
+	flags := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+	if !force {
+		flags = flags | os.O_EXCL
+	}
+
+	dstDir := filepath.Dir(dst)
+	if dstDir != "." {
+		err = os.MkdirAll(dstDir, 0777) // leave it to umask
+		if err != nil {
+			return err
+		}
+	}
+
+	dstf, err := os.OpenFile(dst, flags, 0666) // leave it to umask
+	if err != nil {
+		return err
+	}
+	defer dstf.Close()
+
+	_, err = io.Copy(dstf, srcf)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/testdata/.vervet.yaml
+++ b/testdata/.vervet.yaml
@@ -27,8 +27,8 @@ apis:
       - include: 'resources/include.yaml'
       - inline: |-
           servers:
-            - url: https://example.com/api/v3
-              description: Test API v3
+            - url: https://example.com/api/rest
+              description: Test REST API
     output:
       path: 'output'
       linter: compiled-rules

--- a/testdata/output/2021-06-01~experimental/spec.json
+++ b/testdata/output/2021-06-01~experimental/spec.json
@@ -650,8 +650,8 @@
   },
   "servers": [
     {
-      "description": "Test API v3",
-      "url": "https://example.com/api/v3"
+      "description": "Test REST API",
+      "url": "https://example.com/api/rest"
     }
   ],
   "tags": [

--- a/testdata/output/2021-06-01~experimental/spec.yaml
+++ b/testdata/output/2021-06-01~experimental/spec.yaml
@@ -454,8 +454,8 @@ paths:
         "500":
           $ref: '#/components/responses/500'
 servers:
-- description: Test API v3
-  url: https://example.com/api/v3
+- description: Test REST API
+  url: https://example.com/api/rest
 tags:
 - description: Something
   name: Something

--- a/testdata/output/2021-06-04~experimental/spec.json
+++ b/testdata/output/2021-06-04~experimental/spec.json
@@ -887,8 +887,8 @@
   },
   "servers": [
     {
-      "description": "Test API v3",
-      "url": "https://example.com/api/v3"
+      "description": "Test REST API",
+      "url": "https://example.com/api/rest"
     }
   ],
   "tags": [

--- a/testdata/output/2021-06-04~experimental/spec.yaml
+++ b/testdata/output/2021-06-04~experimental/spec.yaml
@@ -620,8 +620,8 @@ paths:
       x-snyk-api-version: 2021-06-04~experimental
     x-snyk-api-resource: projects
 servers:
-- description: Test API v3
-  url: https://example.com/api/v3
+- description: Test REST API
+  url: https://example.com/api/rest
 tags:
 - description: Projects
   name: Projects

--- a/testdata/output/2021-06-07~experimental/spec.json
+++ b/testdata/output/2021-06-07~experimental/spec.json
@@ -887,8 +887,8 @@
   },
   "servers": [
     {
-      "description": "Test API v3",
-      "url": "https://example.com/api/v3"
+      "description": "Test REST API",
+      "url": "https://example.com/api/rest"
     }
   ],
   "tags": [

--- a/testdata/output/2021-06-07~experimental/spec.yaml
+++ b/testdata/output/2021-06-07~experimental/spec.yaml
@@ -620,8 +620,8 @@ paths:
       x-snyk-api-version: 2021-06-04~experimental
     x-snyk-api-resource: projects
 servers:
-- description: Test API v3
-  url: https://example.com/api/v3
+- description: Test REST API
+  url: https://example.com/api/rest
 tags:
 - description: Projects
   name: Projects

--- a/testdata/output/2021-06-13~beta/spec.json
+++ b/testdata/output/2021-06-13~beta/spec.json
@@ -758,8 +758,8 @@
   },
   "servers": [
     {
-      "description": "Test API v3",
-      "url": "https://example.com/api/v3"
+      "description": "Test REST API",
+      "url": "https://example.com/api/rest"
     }
   ],
   "tags": [

--- a/testdata/output/2021-06-13~beta/spec.yaml
+++ b/testdata/output/2021-06-13~beta/spec.yaml
@@ -525,8 +525,8 @@ paths:
         "500":
           $ref: '#/components/responses/500'
 servers:
-- description: Test API v3
-  url: https://example.com/api/v3
+- description: Test REST API
+  url: https://example.com/api/rest
 tags:
 - description: Something
   name: Something

--- a/testdata/output/2021-06-13~experimental/spec.json
+++ b/testdata/output/2021-06-13~experimental/spec.json
@@ -995,8 +995,8 @@
   },
   "servers": [
     {
-      "description": "Test API v3",
-      "url": "https://example.com/api/v3"
+      "description": "Test REST API",
+      "url": "https://example.com/api/rest"
     }
   ],
   "tags": [

--- a/testdata/output/2021-06-13~experimental/spec.yaml
+++ b/testdata/output/2021-06-13~experimental/spec.yaml
@@ -691,8 +691,8 @@ paths:
       x-snyk-api-version: 2021-06-04~experimental
     x-snyk-api-resource: projects
 servers:
-- description: Test API v3
-  url: https://example.com/api/v3
+- description: Test REST API
+  url: https://example.com/api/rest
 tags:
 - description: Projects
   name: Projects

--- a/testdata/output/2021-08-20~beta/spec.json
+++ b/testdata/output/2021-08-20~beta/spec.json
@@ -758,8 +758,8 @@
   },
   "servers": [
     {
-      "description": "Test API v3",
-      "url": "https://example.com/api/v3"
+      "description": "Test REST API",
+      "url": "https://example.com/api/rest"
     }
   ],
   "tags": [

--- a/testdata/output/2021-08-20~beta/spec.yaml
+++ b/testdata/output/2021-08-20~beta/spec.yaml
@@ -525,8 +525,8 @@ paths:
         "500":
           $ref: '#/components/responses/500'
 servers:
-- description: Test API v3
-  url: https://example.com/api/v3
+- description: Test REST API
+  url: https://example.com/api/rest
 tags:
 - description: Something
   name: Something

--- a/testdata/output/2021-08-20~experimental/spec.json
+++ b/testdata/output/2021-08-20~experimental/spec.json
@@ -1060,8 +1060,8 @@
   },
   "servers": [
     {
-      "description": "Test API v3",
-      "url": "https://example.com/api/v3"
+      "description": "Test REST API",
+      "url": "https://example.com/api/rest"
     }
   ],
   "tags": [

--- a/testdata/output/2021-08-20~experimental/spec.yaml
+++ b/testdata/output/2021-08-20~experimental/spec.yaml
@@ -733,8 +733,8 @@ paths:
       x-snyk-api-version: 2021-06-04~experimental
     x-snyk-api-resource: projects
 servers:
-- description: Test API v3
-  url: https://example.com/api/v3
+- description: Test REST API
+  url: https://example.com/api/rest
 tags:
 - description: Projects
   name: Projects


### PR DESCRIPTION
Why?

Some services have a need to write compiled OpenAPI specs to multiple
destinations. This tends to happen in Typescript services in which we
want to write compiled OpenAPI specs to two places:

- src/**, for commiting into git and ingesting into Backstage
- dist/**, for runtime module access to compiled specs

We could just npm script this in these services, but when a project has
several APIs, this can become fragile -- you now have to keep
file-copying-scripts in sync with Vervet config. Miss something, and what
worked in local dev breaks in deployments.

To simplify this and reduce the error surface, Vervet can instead allow
declaring multiple output paths per API.