### PR TITLE
feat: Package application as a nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 
 **/server
 config.json
+result

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,17 @@
-{ pkgs ? import <nixpkgs> {} }:
-  pkgs.mkShell {
-    nativeBuildInputs = with pkgs.buildPackages; [
-      go envsubst
-    ];
-    shellHook = ''
-      export GOPATH="$HOME/.cache/gopaths/$(sha256sum <<<$(pwd) | awk '{print $1}')"
-    '';
-}
+{ buildGoModule, lib }:
 
+buildGoModule rec {
+  pname = "vervet";
+  version = "4.6.6";
+  src = ./.;
+
+  vendorSha256 = null;
+  proxyVendor = true;
+
+  meta = with lib; {
+    description = "API resource versioning tool";
+    homepage = "https://github.com/snyk/vervet";
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+  subPackages = [ "cmd/vervet" ];
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1648297722,
+        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1648219316,
+        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "API resource versioning tool";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
+      in rec {
+        packages = flake-utils.lib.flattenTree {
+          vervet = pkgs.callPackage ./default.nix { };
+        };
+        defaultPackage = packages.vervet;
+        defaultApp = flake-utils.lib.mkApp { drv = packages.vervet; };
+        devShell = pkgs.callPackage ./shell.nix { inherit pkgs; };
+      });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import <nixpkgs> { } }:
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs.buildPackages; [ go_1_17 envsubst ];
+  shellHook = ''
+    export GOPATH="$HOME/.cache/gopaths/$(sha256sum <<<$(pwd) | awk '{print $1}')"
+  '';
+}
+


### PR DESCRIPTION
Nix is cool, flakes are the future, the cool future is now for this
repository. This will allow nix flake users to run the tool by using:

nix run github:snyk/vervet

This should be compatible with plain nix but I haven't tested that.