### PR TITLE
fix: backstage API: remove version label, tilde from title

### DIFF
--- a/internal/backstage/backstage.go
+++ b/internal/backstage/backstage.go
@@ -21,7 +21,6 @@ import (
 
 const (
 	backstageVersion   = "backstage.io/v1alpha1"
-	snykApiVersion     = "api.snyk.io/version"
 	snykApiVersionDate = "api.snyk.io/version-date"
 	snykApiStability   = "api.snyk.io/version-stability"
 	snykApiLifecycle   = "api.snyk.io/version-lifecycle"
@@ -274,10 +273,9 @@ func (c *CatalogInfo) vervetAPI(doc *vervet.Document, root string) (*API, error)
 		Kind:       "API",
 		Metadata: Metadata{
 			Name:        toBackstageName(doc.Info.Title) + "_" + version.DateString() + "_" + version.Stability.String(),
-			Title:       doc.Info.Title + " " + version.String(),
+			Title:       doc.Info.Title + " " + version.DateString() + " " + version.Stability.String(),
 			Description: doc.Info.Description,
 			Labels: map[string]string{
-				snykApiVersion:     version.String(),
 				snykApiVersionDate: version.DateString(),
 				snykApiStability:   version.Stability.String(),
 				snykApiLifecycle:   lifecycle.String(),

--- a/internal/backstage/backstage_test.go
+++ b/internal/backstage/backstage_test.go
@@ -54,7 +54,6 @@ metadata:
   annotations:
     api.snyk.io/generated-by: vervet
   labels:
-    api.snyk.io/version: 2021-06-04~experimental
     api.snyk.io/version-date: "2021-06-04"
     api.snyk.io/version-lifecycle: sunset
     api.snyk.io/version-stability: experimental

--- a/testdata/catalog-vervet-apis.yaml
+++ b/testdata/catalog-vervet-apis.yaml
@@ -3,11 +3,10 @@ apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
   name: Registry_2021-06-01_experimental
-  title: Registry 2021-06-01~experimental
+  title: Registry 2021-06-01 experimental
   annotations:
     api.snyk.io/generated-by: vervet
   labels:
-    api.snyk.io/version: 2021-06-01~experimental
     api.snyk.io/version-date: "2021-06-01"
     api.snyk.io/version-lifecycle: sunset
     api.snyk.io/version-stability: experimental
@@ -27,11 +26,10 @@ apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
   name: Registry_2021-06-04_experimental
-  title: Registry 2021-06-04~experimental
+  title: Registry 2021-06-04 experimental
   annotations:
     api.snyk.io/generated-by: vervet
   labels:
-    api.snyk.io/version: 2021-06-04~experimental
     api.snyk.io/version-date: "2021-06-04"
     api.snyk.io/version-lifecycle: sunset
     api.snyk.io/version-stability: experimental
@@ -51,11 +49,10 @@ apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
   name: Registry_2021-06-07_experimental
-  title: Registry 2021-06-07~experimental
+  title: Registry 2021-06-07 experimental
   annotations:
     api.snyk.io/generated-by: vervet
   labels:
-    api.snyk.io/version: 2021-06-07~experimental
     api.snyk.io/version-date: "2021-06-07"
     api.snyk.io/version-lifecycle: sunset
     api.snyk.io/version-stability: experimental
@@ -75,11 +72,10 @@ apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
   name: Registry_2021-06-13_beta
-  title: Registry 2021-06-13~beta
+  title: Registry 2021-06-13 beta
   annotations:
     api.snyk.io/generated-by: vervet
   labels:
-    api.snyk.io/version: 2021-06-13~beta
     api.snyk.io/version-date: "2021-06-13"
     api.snyk.io/version-lifecycle: released
     api.snyk.io/version-stability: beta
@@ -99,11 +95,10 @@ apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
   name: Registry_2021-06-13_experimental
-  title: Registry 2021-06-13~experimental
+  title: Registry 2021-06-13 experimental
   annotations:
     api.snyk.io/generated-by: vervet
   labels:
-    api.snyk.io/version: 2021-06-13~experimental
     api.snyk.io/version-date: "2021-06-13"
     api.snyk.io/version-lifecycle: sunset
     api.snyk.io/version-stability: experimental
@@ -123,11 +118,10 @@ apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
   name: Registry_2021-08-20_beta
-  title: Registry 2021-08-20~beta
+  title: Registry 2021-08-20 beta
   annotations:
     api.snyk.io/generated-by: vervet
   labels:
-    api.snyk.io/version: 2021-08-20~beta
     api.snyk.io/version-date: "2021-08-20"
     api.snyk.io/version-lifecycle: released
     api.snyk.io/version-stability: beta
@@ -147,11 +141,10 @@ apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
   name: Registry_2021-08-20_experimental
-  title: Registry 2021-08-20~experimental
+  title: Registry 2021-08-20 experimental
   annotations:
     api.snyk.io/generated-by: vervet
   labels:
-    api.snyk.io/version: 2021-08-20~experimental
     api.snyk.io/version-date: "2021-08-20"
     api.snyk.io/version-lifecycle: sunset
     api.snyk.io/version-stability: experimental


### PR DESCRIPTION
The tilde `~` in version strings seem to cause problems for our
Backstage ingest of API entities, and the `api.snyk.io/version` label is
redundant, (same info is in version-date and version-stability) so it is removed.

The error we see in Backstage:

```
{"error":{"name":"Error","message":"InputError: Policy check failed; caused by Error: \"labels.api.snyk.io/version\" is not valid; expected a string that is sequences of [a-zA-Z0-9] separated by any of [-_.], at most 63 characters in total but found \"2021-08-13~experimental\". To learn more about catalog file format, visit: https://github.com/backstage/backstage/blob/master/docs/architecture-decisions/adr002-default-catalog-file-format.md","level":"error","service":"backstage","stack":"Error: InputError: Policy check failed; caused by Error: \"labels.api.snyk.io/version\" is not valid; expected a string that is sequences of [a-zA-Z0-9] separated by any of [-_.], at most 63 characters in total but found \"2021-08-13~experimental\". To learn more about catalog file format, visit: https://github.com/backstage/backstage/blob/master/docs/architecture-decisions/adr002-default-catalog-file-format.md\n at DefaultLocationService.processEntities (/usr/src/app/node_modules/@backstage/plugin-catalog-backend/dist/index.cjs.js:1820:15)\n at runMicrotasks (<anonymous>)\n at processTicksAndRejections (internal/process/task_queues.js:95:5)\n at async DefaultLocationService.dryRunCreateLocation (/usr/src/app/node_modules/@backstage/plugin-catalog-backend/dist/index.cjs.js:1849:22)\n at async /usr/src/app/node_modules/@backstage/plugin-catalog-backend/dist/index.cjs.js:2839:22"},"request":{"method":"POST","url":"/locations?dryRun=true"},"response":{"statusCode":500}}
```

Also removing the tilde `~` from the API title as it seems to cause the
rendered title in Backstage to get truncated.