### PR TITLE
feat: use fs.FS for generators

### DIFF
--- a/config/generator.go
+++ b/config/generator.go
@@ -1,6 +1,8 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Generators defines a named map of Generator instances.
 type Generators map[string]*Generator

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -1,0 +1,53 @@
+package generate_test
+
+import (
+	"os"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/snyk/vervet/v4/generate"
+	"github.com/snyk/vervet/v4/testdata"
+)
+
+func TestGenerateFS(t *testing.T) {
+	c := qt.New(t)
+	out := c.TempDir()
+
+	fs := fstest.MapFS{
+		"generator.yaml": &fstest.MapFile{
+			Data: []byte(`
+version-readme:
+  scope: version
+  filename: "` + out + `/{{.API}}/{{.Resource}}/{{.Version.DateString}}/README"
+  template: "/README.tmpl"
+`),
+			Mode: 0666,
+		},
+		"README.tmpl": &fstest.MapFile{
+			Data: []byte(`
+This is a generated scaffold for version {{ .Version.String }} of the
+{{ .Resource }} resource in API {{ .API }}.
+`),
+			Mode: 0666,
+		},
+	}
+
+	params := generate.GeneratorParams{
+		ProjectDir:     testdata.Path("."),
+		ConfigFile:     testdata.Path(".vervet.yaml"),
+		GeneratorsFile: "/generator.yaml",
+		Generators:     []string{"version-readme"},
+		FS:             fs,
+	}
+	err := generate.Generate(params)
+	c.Assert(err, qt.IsNil)
+
+	contents, err := os.ReadFile(out + "/testdata/hello-world/2021-06-01/README")
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, `
+This is a generated scaffold for version 2021-06-01~experimental of the
+hello-world resource in API testdata.
+`)
+}

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"path/filepath"
+
 	"github.com/urfave/cli/v2"
 
 	"github.com/snyk/vervet/v4/generate"
@@ -43,11 +45,17 @@ func Generate(ctx *cli.Context) error {
 		generators = append(generators, ctx.Args().Get(i))
 	}
 
+	genFile := ctx.String("generators")
+	genFile, err = filepath.Abs(genFile)
+	if err != nil {
+		return err
+	}
+
 	params := generate.GeneratorParams{
 		ProjectDir:     projectDir,
 		ConfigFile:     configFile,
 		Generators:     generators,
-		GeneratorsFile: ctx.String("generators"),
+		GeneratorsFile: genFile,
 		Debug:          ctx.Bool("debug"),
 		DryRun:         ctx.Bool("dry-run"),
 	}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -153,7 +153,7 @@ func (g *Generator) resolveFilename(filenameTemplate string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return buf.String(), nil
+	return filepath.Abs(buf.String())
 }
 
 // Option configures a Generator.

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -90,7 +90,7 @@ func New(conf *config.Generator, options ...Option) (*Generator, error) {
 		}
 	}
 
-	// Resolve the template filename... with a template.  Only .Here is and .Cwd
+	// Resolve the template filename... with a template.  Only .Here and .Cwd
 	// are supported, not full scope. Just enough to locate files relative to
 	// the config.
 	templateFilename, err := g.resolveFilename(conf.Template)

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/ghodss/yaml"
@@ -29,6 +31,7 @@ type Generator struct {
 	dryRun bool
 	force  bool
 	here   string
+	fs     fs.FS
 }
 
 // NewMap instanstiates a map of Generators from configuration.
@@ -67,6 +70,12 @@ func New(conf *config.Generator, options ...Option) (*Generator, error) {
 		}
 	}
 
+	// If no FS has been provided, use the DirFS for root.
+	if g.fs == nil {
+		fs := os.DirFS("/")
+		g.fs = fs
+	}
+
 	// Resolve the template 'functions'... with a template. Only .Here is
 	// supported, not full scope. Just enough to locate files relative to the
 	// config.
@@ -81,17 +90,24 @@ func New(conf *config.Generator, options ...Option) (*Generator, error) {
 		}
 	}
 
-	// Resolve the template filename... with a template. Only .Here is
-	// supported, not full scope. Just enough to locate files relative to the
-	// config.
+	// Resolve the template filename... with a template.  Only .Here is and .Cwd
+	// are supported, not full scope. Just enough to locate files relative to
+	// the config.
 	templateFilename, err := g.resolveFilename(conf.Template)
 	if err != nil {
 		return nil, fmt.Errorf("%w: (generators.%s.template)", err, conf.Name)
 	}
 
+	// Remove the leading slash in the filepath -- fs.FS.Open does not accept
+	// rooted paths.
+	templateFilename = strings.TrimPrefix(templateFilename, "/")
 	// Parse & wire up other templates: contents, filename or files. These do
 	// support full scope.
-	contentsTemplate, err := ioutil.ReadFile(templateFilename)
+	templateFile, err := g.fs.Open(templateFilename)
+	if err != nil {
+		return nil, err
+	}
+	contentsTemplate, err := ioutil.ReadAll(templateFile)
 	if err != nil {
 		return nil, fmt.Errorf("%w: (generators.%s.contents)", err, conf.Name)
 	}
@@ -126,8 +142,13 @@ func (g *Generator) resolveFilename(filenameTemplate string) (string, error) {
 		return "", err
 	}
 	var buf bytes.Buffer
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
 	err = t.ExecuteTemplate(&buf, "", map[string]string{
 		"Here": g.here,
+		"Cwd":  cwd,
 	})
 	if err != nil {
 		return "", err
@@ -165,6 +186,13 @@ func DryRun(dryRun bool) Option {
 func Here(here string) Option {
 	return func(g *Generator) {
 		g.here = here
+	}
+}
+
+// Filesystem sets the filesytem that the generator checks for templates.
+func Filesystem(FS fs.FS) Option {
+	return func(g *Generator) {
+		g.fs = FS
 	}
 }
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -27,89 +28,95 @@ func setup(c *qt.C) {
 
 func TestVersionScope(t *testing.T) {
 	c := qt.New(t)
-	setup(c)
+	for _, prefix := range []string{"", "{{.Cwd}}/"} {
+		c.Run(fmt.Sprintf("template prefix %q", prefix), func(c *qt.C) {
+			setup(c)
 
-	configBuf, err := ioutil.ReadFile(".vervet.yaml")
-	c.Assert(err, qt.IsNil)
-	proj, err := config.Load(bytes.NewBuffer(configBuf))
-	c.Assert(err, qt.IsNil)
+			configBuf, err := ioutil.ReadFile(".vervet.yaml")
+			c.Assert(err, qt.IsNil)
+			proj, err := config.Load(bytes.NewBuffer(configBuf))
+			c.Assert(err, qt.IsNil)
 
-	out := c.TempDir()
+			out := c.TempDir()
 
-	versionReadme := `
+			versionReadme := `
 version-readme:
   scope: version
   filename: "{{.Here}}/{{.API}}/{{.Resource}}/{{.Version.DateString}}/README"
-  template: "{{.Cwd}}/.vervet/resource/version/README.tmpl"
+  template: "` + prefix + `.vervet/resource/version/README.tmpl"
 `
-	generatorsConf, err := config.LoadGenerators(bytes.NewBufferString(versionReadme))
-	c.Assert(err, qt.IsNil)
+			generatorsConf, err := config.LoadGenerators(bytes.NewBufferString(versionReadme))
+			c.Assert(err, qt.IsNil)
 
-	genReadme, err := New(generatorsConf["version-readme"], Debug(true), Here(out))
-	c.Assert(err, qt.IsNil)
+			genReadme, err := New(generatorsConf["version-readme"], Debug(true), Here(out))
+			c.Assert(err, qt.IsNil)
 
-	resources, err := MapResources(proj)
-	c.Assert(err, qt.IsNil)
-	files, err := genReadme.Execute(resources)
-	c.Assert(err, qt.IsNil)
-	c.Assert(files, qt.ContentEquals, []string{
-		out + "/testdata/hello-world/2021-06-01/README",
-		out + "/testdata/hello-world/2021-06-07/README",
-		out + "/testdata/hello-world/2021-06-13/README",
-		out + "/testdata/projects/2021-06-04/README",
-		out + "/testdata/projects/2021-08-20/README",
-	})
+			resources, err := MapResources(proj)
+			c.Assert(err, qt.IsNil)
+			files, err := genReadme.Execute(resources)
+			c.Assert(err, qt.IsNil)
+			c.Assert(files, qt.ContentEquals, []string{
+				out + "/testdata/hello-world/2021-06-01/README",
+				out + "/testdata/hello-world/2021-06-07/README",
+				out + "/testdata/hello-world/2021-06-13/README",
+				out + "/testdata/projects/2021-06-04/README",
+				out + "/testdata/projects/2021-08-20/README",
+			})
 
-	for _, test := range []struct {
-		resource, version string
-	}{{
-		"projects", "2021-06-04",
-	}, {
-		"projects", "2021-08-20",
-	}} {
-		readme, err := ioutil.ReadFile(out + "/testdata/" + test.resource + "/" + test.version + "/README")
-		c.Assert(err, qt.IsNil)
-		c.Assert(string(readme), qt.Equals, ``+
-			`This is a generated scaffold for version `+test.version+"~experimental of the\n"+
-			test.resource+" resource in API testdata.\n\n")
+			for _, test := range []struct {
+				resource, version string
+			}{{
+				"projects", "2021-06-04",
+			}, {
+				"projects", "2021-08-20",
+			}} {
+				readme, err := ioutil.ReadFile(out + "/testdata/" + test.resource + "/" + test.version + "/README")
+				c.Assert(err, qt.IsNil)
+				c.Assert(string(readme), qt.Equals, ``+
+					`This is a generated scaffold for version `+test.version+"~experimental of the\n"+
+					test.resource+" resource in API testdata.\n\n")
+			}
+		})
 	}
 }
 
 func TestResourceScope(t *testing.T) {
 	c := qt.New(t)
-	setup(c)
+	for _, prefix := range []string{"", "{{.Cwd}}/"} {
+		c.Run(fmt.Sprintf("template prefix %q", prefix), func(c *qt.C) {
+			setup(c)
 
-	configBuf, err := ioutil.ReadFile(".vervet.yaml")
-	c.Assert(err, qt.IsNil)
-	proj, err := config.Load(bytes.NewBuffer(configBuf))
-	c.Assert(err, qt.IsNil)
+			configBuf, err := ioutil.ReadFile(".vervet.yaml")
+			c.Assert(err, qt.IsNil)
+			proj, err := config.Load(bytes.NewBuffer(configBuf))
+			c.Assert(err, qt.IsNil)
 
-	out := c.TempDir()
+			out := c.TempDir()
 
-	versionReadme := `
+			versionReadme := `
 resource-routes:
   scope: resource
   filename: "{{.Here}}/{{ .API }}/{{ .Resource }}/routes.ts"
-  template: "{{.Cwd}}/.vervet/resource/routes.ts.tmpl"
+  template: "` + prefix + `.vervet/resource/routes.ts.tmpl"
 `
-	generatorsConf, err := config.LoadGenerators(bytes.NewBufferString(versionReadme))
-	c.Assert(err, qt.IsNil)
+			generatorsConf, err := config.LoadGenerators(bytes.NewBufferString(versionReadme))
+			c.Assert(err, qt.IsNil)
 
-	genReadme, err := New(generatorsConf["resource-routes"], Debug(true), Here(out))
-	c.Assert(err, qt.IsNil)
+			genReadme, err := New(generatorsConf["resource-routes"], Debug(true), Here(out))
+			c.Assert(err, qt.IsNil)
 
-	resources, err := MapResources(proj)
-	c.Assert(err, qt.IsNil)
-	files, err := genReadme.Execute(resources)
-	c.Assert(err, qt.IsNil)
-	c.Assert(files, qt.ContentEquals, []string{
-		out + "/testdata/hello-world/routes.ts",
-		out + "/testdata/projects/routes.ts",
-	})
+			resources, err := MapResources(proj)
+			c.Assert(err, qt.IsNil)
+			files, err := genReadme.Execute(resources)
+			c.Assert(err, qt.IsNil)
+			c.Assert(files, qt.ContentEquals, []string{
+				out + "/testdata/hello-world/routes.ts",
+				out + "/testdata/projects/routes.ts",
+			})
 
-	routes, err := ioutil.ReadFile(out + "/testdata/hello-world/routes.ts")
-	c.Assert(err, qt.IsNil)
-	c.Assert(string(routes), qt.Equals, `
+			routes, err := ioutil.ReadFile(out + "/testdata/hello-world/routes.ts")
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(routes), qt.Equals, `
 import { versions } from '@snyk/rest-node-libs';
 import * as v2021_06_13 './2021-06-13';
 import * as v2021_06_01 './2021-06-01';
@@ -140,9 +147,9 @@ export const helloWorldGetOne = versions([
 ]);
 `[1:])
 
-	routes, err = ioutil.ReadFile(out + "/testdata/projects/routes.ts")
-	c.Assert(err, qt.IsNil)
-	c.Assert(string(routes), qt.Equals, `
+			routes, err = ioutil.ReadFile(out + "/testdata/projects/routes.ts")
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(routes), qt.Equals, `
 import { versions } from '@snyk/rest-node-libs';
 import * as v2021_08_20 './2021-08-20';
 import * as v2021_06_04 './2021-06-04';
@@ -160,6 +167,8 @@ export const getOrgsProjects = versions([
   },
 ]);
 `[1:])
+		})
+	}
 }
 
 func TestFunctions(t *testing.T) {
@@ -396,40 +405,44 @@ export type QueryVersion = string;
 
 func TestDryRun(t *testing.T) {
 	c := qt.New(t)
-	setup(c)
+	for _, prefix := range []string{"", "{{.Cwd}}/"} {
+		c.Run(fmt.Sprintf("template prefix %q", prefix), func(c *qt.C) {
+			setup(c)
 
-	configBuf, err := ioutil.ReadFile(".vervet.yaml")
-	c.Assert(err, qt.IsNil)
-	proj, err := config.Load(bytes.NewBuffer(configBuf))
-	c.Assert(err, qt.IsNil)
+			configBuf, err := ioutil.ReadFile(".vervet.yaml")
+			c.Assert(err, qt.IsNil)
+			proj, err := config.Load(bytes.NewBuffer(configBuf))
+			c.Assert(err, qt.IsNil)
 
-	out := c.TempDir()
+			out := c.TempDir()
 
-	versionReadme := `
+			versionReadme := `
 version-readme:
   scope: version
   filename: "{{.Here}}/{{.API}}/{{.Resource}}/{{.Version.DateString}}/README"
-  template: "{{.Cwd}}/.vervet/resource/version/README.tmpl"
+  template: "` + prefix + `.vervet/resource/version/README.tmpl"
 `
-	generatorsConf, err := config.LoadGenerators(bytes.NewBufferString(versionReadme))
-	c.Assert(err, qt.IsNil)
+			generatorsConf, err := config.LoadGenerators(bytes.NewBufferString(versionReadme))
+			c.Assert(err, qt.IsNil)
 
-	genReadme, err := New(generatorsConf["version-readme"], Debug(true), Here(out), DryRun(true))
-	c.Assert(err, qt.IsNil)
+			genReadme, err := New(generatorsConf["version-readme"], Debug(true), Here(out), DryRun(true))
+			c.Assert(err, qt.IsNil)
 
-	resources, err := MapResources(proj)
-	c.Assert(err, qt.IsNil)
-	files, err := genReadme.Execute(resources)
-	c.Assert(err, qt.IsNil)
-	c.Assert(files, qt.ContentEquals, []string{
-		out + "/testdata/hello-world/2021-06-01/README",
-		out + "/testdata/hello-world/2021-06-07/README",
-		out + "/testdata/hello-world/2021-06-13/README",
-		out + "/testdata/projects/2021-06-04/README",
-		out + "/testdata/projects/2021-08-20/README",
-	})
+			resources, err := MapResources(proj)
+			c.Assert(err, qt.IsNil)
+			files, err := genReadme.Execute(resources)
+			c.Assert(err, qt.IsNil)
+			c.Assert(files, qt.ContentEquals, []string{
+				out + "/testdata/hello-world/2021-06-01/README",
+				out + "/testdata/hello-world/2021-06-07/README",
+				out + "/testdata/hello-world/2021-06-13/README",
+				out + "/testdata/projects/2021-06-04/README",
+				out + "/testdata/projects/2021-08-20/README",
+			})
 
-	actualFiles, err := filepath.Glob(out + "/*/*/*/README")
-	c.Assert(err, qt.IsNil)
-	c.Assert(actualFiles, qt.HasLen, 0)
+			actualFiles, err := filepath.Glob(out + "/*/*/*/README")
+			c.Assert(err, qt.IsNil)
+			c.Assert(actualFiles, qt.HasLen, 0)
+		})
+	}
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -40,7 +40,7 @@ func TestVersionScope(t *testing.T) {
 version-readme:
   scope: version
   filename: "{{.Here}}/{{.API}}/{{.Resource}}/{{.Version.DateString}}/README"
-  template: ".vervet/resource/version/README.tmpl"
+  template: "{{.Cwd}}/.vervet/resource/version/README.tmpl"
 `
 	generatorsConf, err := config.LoadGenerators(bytes.NewBufferString(versionReadme))
 	c.Assert(err, qt.IsNil)
@@ -90,7 +90,7 @@ func TestResourceScope(t *testing.T) {
 resource-routes:
   scope: resource
   filename: "{{.Here}}/{{ .API }}/{{ .Resource }}/routes.ts"
-  template: ".vervet/resource/routes.ts.tmpl"
+  template: "{{.Cwd}}/.vervet/resource/routes.ts.tmpl"
 `
 	generatorsConf, err := config.LoadGenerators(bytes.NewBufferString(versionReadme))
 	c.Assert(err, qt.IsNil)
@@ -409,7 +409,7 @@ func TestDryRun(t *testing.T) {
 version-readme:
   scope: version
   filename: "{{.Here}}/{{.API}}/{{.Resource}}/{{.Version.DateString}}/README"
-  template: ".vervet/resource/version/README.tmpl"
+  template: "{{.Cwd}}/.vervet/resource/version/README.tmpl"
 `
 	generatorsConf, err := config.LoadGenerators(bytes.NewBufferString(versionReadme))
 	c.Assert(err, qt.IsNil)


### PR DESCRIPTION
rest-go-generate uses vervet's generator code to produce code for go
projects. To create a single binary, the generators.yaml and template
files for rest-go-generate are provided with embed.FS

To avoid special casing, vervet now always loads generation files from
an fs.FS object, using os.DirFS mounted at root if no other option is
provided.