### PR TITLE
fix: Allow nix package to be build on clean systems

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,10 @@
-{ buildGoModule, lib }:
-
+{ buildGoModule, lib, lastMod }:
 buildGoModule rec {
   pname = "vervet";
-  version = "4.6.6";
+  version = builtins.substring 0 8 lastMod;
   src = ./.;
 
-  vendorSha256 = null;
-  proxyVendor = true;
+  vendorSha256 = "sha256-KcxaAOp9+d2DN4qFmmNDH3Di+TmiqhTbLsujh2aKRmk=";
 
   meta = with lib; {
     description = "API resource versioning tool";

--- a/flake.nix
+++ b/flake.nix
@@ -12,10 +12,9 @@
       let pkgs = nixpkgs.legacyPackages.${system};
       in rec {
         packages = flake-utils.lib.flattenTree {
-          vervet = pkgs.callPackage ./default.nix { inherit lastMod; };
+          default = pkgs.callPackage ./default.nix { inherit lastMod; };
         };
-        defaultPackage = packages.vervet;
-        defaultApp = flake-utils.lib.mkApp { drv = packages.vervet; };
+        apps.default = flake-utils.lib.mkApp { drv = packages.default; };
         devShell = pkgs.callPackage ./shell.nix { inherit pkgs; };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -7,11 +7,12 @@
   };
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+    let lastMod = self.lastModifiedDate or self.lastModified or "19700101";
+    in flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system};
       in rec {
         packages = flake-utils.lib.flattenTree {
-          vervet = pkgs.callPackage ./default.nix { };
+          vervet = pkgs.callPackage ./default.nix { inherit lastMod; };
         };
         defaultPackage = packages.vervet;
         defaultApp = flake-utils.lib.mkApp { drv = packages.vervet; };


### PR DESCRIPTION
proxyVendor was set which assumes that the go dependencies are available
in the building systems nix store, which is rarely the case. This patch
allows nix to download the dependencies when the requested package is
being built.

We also set the version to the last modified date so this flake will get
a new version number without having to update the version number
manually.