### PR TITLE
fix: enable config to pass role arn

### DIFF
--- a/vervet-underground/config/config.go
+++ b/vervet-underground/config/config.go
@@ -35,6 +35,7 @@ type S3Config struct {
 	AccessKey  string
 	SecretKey  string
 	SessionKey string
+	RoleArn    string
 }
 
 type GcsConfig struct {

--- a/vervet-underground/server.go
+++ b/vervet-underground/server.go
@@ -240,6 +240,7 @@ func initializeStorage(cfg *config.ServerConfig) (storage.Storage, error) {
 				AccessKey:  cfg.Storage.S3.AccessKey,
 				SecretKey:  cfg.Storage.S3.SecretKey,
 				SessionKey: cfg.Storage.S3.SessionKey,
+				RoleArn:    cfg.Storage.S3.RoleArn,
 			},
 		})
 	case config.StorageTypeGCS:


### PR DESCRIPTION
During testing, we found Roles were not automatically assumed from Kubernetes and had to be specified for the s3 client.

https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/credentials/stscreds#hdr-Assume_Role

```json
{"level":"info","time":1651520340,"message":"services: [https://api.deploy-system/rest]"}
{"level":"error","error":"operation error S3: ListBuckets, https response error StatusCode: 400, RequestID: TQK0VNDP7FV2PAJV, HostID: {SCRUBBED_CODE}, api error AuthorizationHeaderMalformed: The authorization header is malformed; a non-empty Access Key (AKID) must be provided in the credential.","time":1651520340,"message":"failed to call service: S3, operation: ListBuckets, error: https response error StatusCode: 400, RequestID: {SCRUBBED_CODE}, HostID: {SCRUBBED_CODE}, api error AuthorizationHeaderMalformed: The authorization header is malformed; a non-empty Access Key (AKID) must be provided in the credential."}
{"level":"error","error":"api error AuthorizationHeaderMalformed: The authorization header is malformed; a non-empty Access Key (AKID) must be provided in the credential.","cause":"api error AuthorizationHeaderMalformed: The authorization header is malformed; a non-empty Access Key (AKID) must be provided in the credential.","time":1651520340,"message":"UnhandledException"}
{"level":"fatal","time":1651520340,"message":"unable to initialize storage client"}
```