### PR TITLE
fix: enable resolve on collated versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 
 **/server
 config.json
+config.*.test.json
 result

--- a/vervet-underground/internal/storage/mem/mem.go
+++ b/vervet-underground/internal/storage/mem/mem.go
@@ -153,7 +153,15 @@ func (s *Storage) Version(version string) ([]byte, error) {
 		return nil, err
 	}
 
-	spec := s.collatedVersionedSpecs[parsedVersion]
+	spec, ok := s.collatedVersionedSpecs[parsedVersion]
+	if !ok {
+		resolved, err := s.collatedVersions.Resolve(parsedVersion)
+		if err != nil {
+			return nil, err
+		}
+		resolvedSpec := s.collatedVersionedSpecs[resolved]
+		return resolvedSpec.MarshalJSON()
+	}
 	return spec.MarshalJSON()
 }
 

--- a/vervet-underground/internal/storage/mem/mem_test.go
+++ b/vervet-underground/internal/storage/mem/mem_test.go
@@ -80,19 +80,20 @@ func TestCollateVersions(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	tests := []struct {
-		version string
-		empty   bool
+		version        string
+		empty          bool
+		errorCondition qt.Checker
 	}{
-		{"2021-09-16", false},
-		{"2021-01-01", true},
-		{"2021-09-16", false},
+		{"2021-09-16", false, qt.Equals},
+		{"2021-01-01", true, qt.Not(qt.Equals)},
+		{"2021-09-16", false, qt.Equals},
 	}
 	for i, t := range tests {
 		c.Run(fmt.Sprintf("test#%d: %v", i, t), func(c *qt.C) {
 			content, err := s.Version(t.version)
-			c.Assert(err, qt.IsNil)
+			c.Assert(err, t.errorCondition, nil)
 			if t.empty {
-				c.Assert(string(content), qt.Equals, emptySpec)
+				c.Assert(string(content), t.errorCondition, emptySpec)
 				return
 			}
 			c.Assert(string(content), qt.Not(qt.Equals), emptySpec)

--- a/vervet-underground/internal/storage/s3/client.go
+++ b/vervet-underground/internal/storage/s3/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -187,11 +188,28 @@ func (s *Storage) Versions() []string {
 
 // Version implements scraper.Storage.
 func (s *Storage) Version(version string) ([]byte, error) {
-	_, err := vervet.ParseVersion(version)
+	parsedVersion, err := vervet.ParseVersion(version)
 	if err != nil {
 		return nil, err
 	}
-	return s.GetCollatedVersionSpec(version)
+	blob, err := s.GetCollatedVersionSpec(version)
+	if err != nil {
+		collatedVersions := vervet.VersionSlice{}
+		for _, s := range s.Versions() {
+			temp, err := vervet.ParseVersion(s)
+			if err != nil {
+				continue
+			}
+			collatedVersions = append(collatedVersions, temp)
+		}
+		sort.Sort(collatedVersions)
+		resolved, err := collatedVersions.Resolve(parsedVersion)
+		if err != nil {
+			return nil, err
+		}
+		return s.GetCollatedVersionSpec(resolved.String())
+	}
+	return blob, nil
 }
 
 // CollateVersions aggregates versions and revisions from all the services, and produces unified versions and merged specs for all APIs.


### PR DESCRIPTION
This was a miss that prevents the /openapi/experimental lookup
on VU for all storage backends. Required for shared routing

https://github.com/snyk/gloo-edge-api-gateway/pull/374