### PR TITLE
chore: revert sts rotating credentials

### DIFF
--- a/vervet-underground/config/config.go
+++ b/vervet-underground/config/config.go
@@ -35,7 +35,6 @@ type S3Config struct {
 	AccessKey  string
 	SecretKey  string
 	SessionKey string
-	RoleArn    string
 }
 
 type GcsConfig struct {

--- a/vervet-underground/internal/storage/s3/client.go
+++ b/vervet-underground/internal/storage/s3/client.go
@@ -15,10 +15,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/rs/zerolog/log"
@@ -33,7 +31,6 @@ type StaticKeyCredentials struct {
 	AccessKey  string
 	SecretKey  string
 	SessionKey string
-	RoleArn    string // Role Arn used when IamRoleEnabled
 }
 
 // Config Defines S3 client target used in config.LoadDefaultConfig.
@@ -58,9 +55,8 @@ func New(ctx context.Context, awsCfg *Config) (storage.Storage, error) {
 	}
 
 	var options []func(*config.LoadOptions) error
-	var credCache *aws.CredentialsCache
 	/*
-		Secrets should come from volume or IamRole
+		Secrets should come from AWS injected IAM Role volume
 		localstack defaults to static credentials for local dev
 		awsRegion = os.Getenv("AWS_REGION")
 		awsEndpoint = os.Getenv("AWS_ENDPOINT")
@@ -86,17 +82,9 @@ func New(ctx context.Context, awsCfg *Config) (storage.Storage, error) {
 				awsCfg.Credentials.SecretKey,
 				awsCfg.Credentials.SessionKey)),
 			config.WithEndpointResolverWithOptions(customResolver))
-	} else {
-		stsSvc := sts.New(sts.Options{})
-		creds := stscreds.NewAssumeRoleProvider(stsSvc, awsCfg.Credentials.RoleArn)
-		options = append(options, config.WithCredentialsProvider(creds))
-		credCache = aws.NewCredentialsCache(creds)
 	}
 
 	awsCfgLoader, err := config.LoadDefaultConfig(ctx, options...)
-	if credCache != nil {
-		awsCfgLoader.Credentials = credCache
-	}
 
 	if err != nil {
 		log.Error().Err(err).Msg("Cannot load the AWS configs")

--- a/vervet-underground/server.go
+++ b/vervet-underground/server.go
@@ -241,7 +241,6 @@ func initializeStorage(ctx context.Context, cfg *config.ServerConfig) (storage.S
 				AccessKey:  cfg.Storage.S3.AccessKey,
 				SecretKey:  cfg.Storage.S3.SecretKey,
 				SessionKey: cfg.Storage.S3.SessionKey,
-				RoleArn:    cfg.Storage.S3.RoleArn,
 			},
 		})
 	case config.StorageTypeGCS:


### PR DESCRIPTION
We don't need STS when in fact AWS Supports Role based environments for bare metal and EKS.

https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html