### PR TITLE
Fix: Handle success  on bucket found calls and fix idempotent get noise

### DIFF
--- a/vervet-underground/internal/storage/s3/client.go
+++ b/vervet-underground/internal/storage/s3/client.go
@@ -512,16 +512,8 @@ For information on other S3 API error codes see:
 https://aws.github.io/aws-sdk-go-v2/docs/handling-errors/
 */
 func handleAwsError(err error) error {
-	var opErr *smithy.OperationError
 	var apiErr smithy.APIError
 	var re *awshttp.ResponseError
-
-	if errors.As(err, &opErr) {
-		log.Error().Err(err).Msgf("failed to call service: %s, operation: %s, error: %v",
-			opErr.Service(),
-			opErr.Operation(),
-			opErr.Unwrap())
-	}
 
 	if errors.As(err, &re) {
 		log.Error().Err(re).Msgf("failed to call service: %s, status_code: %d, error: %v",

--- a/vervet-underground/internal/storage/s3/client.go
+++ b/vervet-underground/internal/storage/s3/client.go
@@ -451,9 +451,13 @@ func (s *Storage) CreateBucket(ctx context.Context) error {
 	}
 
 	_, err := s.client.HeadBucket(ctx, input)
-	if smith := handleAwsError(err); smith != nil {
-		return smith
+	smith := handleAwsError(err)
+	if smith == nil {
+		return nil
 	}
+	log.Info().
+		Err(err).
+		Msg("Head bucket check failed, continuing to bucket creation")
 
 	bucket, err := s.client.CreateBucket(ctx, create)
 	if smith := handleAwsError(err); smith != nil {

--- a/vervet-underground/internal/storage/s3/client_test.go
+++ b/vervet-underground/internal/storage/s3/client_test.go
@@ -158,3 +158,18 @@ func TestListObjectsAndPrefixes(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(versions, qt.Contains, "2022-02-02")
 }
+
+func TestHandleAwsError(t *testing.T) {
+	c := setup(t)
+	ctx := context.Background()
+
+	st, err := s3.New(ctx, cfg)
+	c.Assert(err, qt.IsNil)
+	client, ok := st.(*s3.Storage)
+	c.Assert(ok, qt.IsTrue)
+
+	// Fail silently
+	res, err := client.GetObject(ctx, storage.CollatedVersionsFolder+"dummy.txt")
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(res), qt.Equals, "")
+}


### PR DESCRIPTION
Found two bugs:

* we didn't correctly return on successful `HeadBucket` requests
* we didn't gracefully fail on 404 NotFound: NoSuchKey `GetObject` requests.

This has been successfully proven in pre-prod environment