### PR TITLE
feat: remove elements matching an exclude pattern

### DIFF
--- a/remove_elements.go
+++ b/remove_elements.go
@@ -1,0 +1,135 @@
+package vervet
+
+import (
+	"reflect"
+	"regexp"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/mitchellh/reflectwalk"
+)
+
+// ExcludePatterns defines patterns matching elements to be removed from an
+// OpenAPI document.
+type ExcludePatterns struct {
+	ExtensionPatterns []string
+	HeaderPatterns    []string
+}
+
+type excluder struct {
+	doc *openapi3.T
+
+	extensionPatterns []*regexp.Regexp
+	headerPatterns    []*regexp.Regexp
+}
+
+// RemoveElements removes those elements from an OpenAPI document matching the
+// given exclude patterns.
+func RemoveElements(doc *openapi3.T, excludes ExcludePatterns) error {
+	ex := &excluder{
+		doc:               doc,
+		extensionPatterns: make([]*regexp.Regexp, len(excludes.ExtensionPatterns)),
+		headerPatterns:    make([]*regexp.Regexp, len(excludes.HeaderPatterns)),
+	}
+	for i, pat := range excludes.ExtensionPatterns {
+		re, err := regexp.Compile(pat)
+		if err != nil {
+			return err
+		}
+		ex.extensionPatterns[i] = re
+	}
+	for i, pat := range excludes.HeaderPatterns {
+		re, err := regexp.Compile(pat)
+		if err != nil {
+			return err
+		}
+		ex.headerPatterns[i] = re
+	}
+	if err := ex.apply(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ex *excluder) apply() error {
+	return reflectwalk.Walk(ex.doc, ex)
+}
+
+// Struct implements reflectwalk.StructWalker
+func (ex *excluder) Struct(v reflect.Value) error {
+	switch v.Interface().(type) {
+	case openapi3.ExtensionProps:
+		ex.applyExtensionProps(v.Addr().Interface().(*openapi3.ExtensionProps))
+	case openapi3.Operation:
+		ex.applyOperation(v.Addr().Interface().(*openapi3.Operation))
+	}
+	return nil
+}
+
+// StructField implements reflectwalk.StructWalker
+func (ex *excluder) StructField(field reflect.StructField, v reflect.Value) error {
+	return nil
+}
+
+func (ex *excluder) applyExtensionProps(extProps *openapi3.ExtensionProps) {
+	exts := map[string]interface{}{}
+	for k, v := range extProps.Extensions {
+		if !ex.isExcludedExtension(k) {
+			exts[k] = v
+		}
+	}
+	extProps.Extensions = exts
+}
+
+func (ex *excluder) applyOperation(op *openapi3.Operation) {
+	var params []*openapi3.ParameterRef
+	for _, p := range op.Parameters {
+		if !ex.isExcludedHeaderParam(p) {
+			params = append(params, p)
+		}
+	}
+	op.Parameters = params
+
+	for _, resp := range op.Responses {
+		if resp.Value == nil {
+			continue
+		}
+		headers := openapi3.Headers{}
+		for headerName, header := range resp.Value.Headers {
+			var matched bool
+			for _, re := range ex.headerPatterns {
+				if re.MatchString(headerName) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				headers[headerName] = header
+			}
+		}
+		resp.Value.Headers = headers
+	}
+}
+
+func (ex *excluder) isExcludedExtension(name string) bool {
+	for _, re := range ex.extensionPatterns {
+		if re.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func (ex *excluder) isExcludedHeaderParam(p *openapi3.ParameterRef) bool {
+	if p.Value == nil {
+		return false
+	}
+	if p.Value.In != "header" {
+		return false
+	}
+	for _, re := range ex.headerPatterns {
+		if re.MatchString(p.Value.Name) {
+			return true
+		}
+	}
+	return false
+}

--- a/remove_elements_test.go
+++ b/remove_elements_test.go
@@ -1,0 +1,76 @@
+package vervet_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/snyk/vervet/v4"
+	"github.com/snyk/vervet/v4/testdata"
+)
+
+func TestRemoveElementsExact(t *testing.T) {
+	c := qt.New(t)
+	doc, err := vervet.NewDocumentFile(testdata.Path("output/2021-08-20~experimental/spec.yaml"))
+	c.Assert(err, qt.IsNil)
+
+	// Establish that the OpenAPI document has these expected features
+
+	c.Assert(doc.Paths["/orgs/{orgId}/projects"].Get.Responses["200"].Value.Headers["snyk-request-id"], qt.Not(qt.IsNil))
+	c.Assert(doc.Paths["/orgs/{orgId}/projects"].Get.Responses["200"].Value.Headers["snyk-version-served"], qt.Not(qt.IsNil))
+	c.Assert(doc.Paths["/orgs/{org_id}/projects/{project_id}"].Delete.Parameters, qt.HasLen, 4)
+	c.Assert(doc.Paths["/orgs/{org_id}/projects/{project_id}"].Delete.Parameters[3].Value.Name, qt.Equals, "x-private-matter")
+
+	c.Assert(doc.Paths["/orgs/{orgId}/projects"].ExtensionProps.Extensions["x-snyk-api-resource"], qt.Not(qt.IsNil))
+	c.Assert(doc.ExtensionProps.Extensions["x-snyk-api-lifecycle"], qt.Not(qt.IsNil))
+
+	// Remove some of them
+
+	err = vervet.RemoveElements(doc.T, vervet.ExcludePatterns{
+		ExtensionPatterns: []string{"x-snyk-api-releases", "x-snyk-api-resource"},
+		HeaderPatterns:    []string{"snyk-request-id", "x-private-matter"},
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Assert their removal
+
+	c.Assert(doc.Paths["/orgs/{orgId}/projects"].Get.Responses["200"].Value.Headers["snyk-request-id"], qt.IsNil)             // now removed
+	c.Assert(doc.Paths["/orgs/{orgId}/projects"].Get.Responses["200"].Value.Headers["snyk-version-served"], qt.Not(qt.IsNil)) // still there
+	c.Assert(doc.Paths["/orgs/{org_id}/projects/{project_id}"].Delete.Parameters, qt.HasLen, 3)                               // x-private-matter removed
+
+	c.Assert(doc.Paths["/orgs/{orgId}/projects"].ExtensionProps.Extensions["x-snyk-api-resource"], qt.IsNil) // now removed
+	c.Assert(doc.ExtensionProps.Extensions["x-snyk-api-lifecycle"], qt.Not(qt.IsNil))                        // still there
+}
+
+func TestRemoveElementsRegex(t *testing.T) {
+	c := qt.New(t)
+	doc, err := vervet.NewDocumentFile(testdata.Path("output/2021-08-20~experimental/spec.yaml"))
+	c.Assert(err, qt.IsNil)
+
+	// Establish that the OpenAPI document has these expected features
+
+	c.Assert(doc.Paths["/orgs/{orgId}/projects"].Get.Responses["200"].Value.Headers["snyk-request-id"], qt.Not(qt.IsNil))
+	c.Assert(doc.Paths["/orgs/{orgId}/projects"].Get.Responses["200"].Value.Headers["snyk-version-served"], qt.Not(qt.IsNil))
+	c.Assert(doc.Paths["/orgs/{org_id}/projects/{project_id}"].Delete.Parameters, qt.HasLen, 4)
+	c.Assert(doc.Paths["/orgs/{org_id}/projects/{project_id}"].Delete.Parameters[3].Value.Name, qt.Equals, "x-private-matter")
+
+	c.Assert(doc.Paths["/orgs/{orgId}/projects"].ExtensionProps.Extensions["x-snyk-api-resource"], qt.Not(qt.IsNil))
+	c.Assert(doc.ExtensionProps.Extensions["x-snyk-api-lifecycle"], qt.Not(qt.IsNil))
+
+	// Remove some of them
+
+	err = vervet.RemoveElements(doc.T, vervet.ExcludePatterns{
+		ExtensionPatterns: []string{"x-snyk-api-r.*"},
+		HeaderPatterns:    []string{"snyk-version-.*", "x-private-.*"},
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Assert their removal
+
+	c.Assert(doc.Paths["/orgs/{orgId}/projects"].Get.Responses["200"].Value.Headers["snyk-request-id"], qt.Not(qt.IsNil)) // still there
+	c.Assert(doc.Paths["/orgs/{orgId}/projects"].Get.Responses["200"].Value.Headers["snyk-version-served"], qt.IsNil)     // now removed
+	c.Assert(doc.Paths["/orgs/{org_id}/projects/{project_id}"].Delete.Parameters, qt.HasLen, 3)                           // x-private-matter removed
+
+	c.Assert(doc.Paths["/orgs/{orgId}/projects"].ExtensionProps.Extensions["x-snyk-api-resource"], qt.IsNil) // now removed
+	c.Assert(doc.ExtensionProps.Extensions["x-snyk-api-lifecycle"], qt.Not(qt.IsNil))                        // still there
+}

--- a/testdata/output/2021-08-20~experimental/spec.json
+++ b/testdata/output/2021-08-20~experimental/spec.json
@@ -1017,6 +1017,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "It's a secret to everybody",
+            "in": "header",
+            "name": "x-private-matter",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/testdata/output/2021-08-20~experimental/spec.yaml
+++ b/testdata/output/2021-08-20~experimental/spec.yaml
@@ -617,6 +617,11 @@ paths:
         required: true
         schema:
           type: string
+      - description: It's a secret to everybody
+        in: header
+        name: x-private-matter
+        schema:
+          type: string
       responses:
         "204":
           description: Project was deleted

--- a/testdata/resource-rules.yaml
+++ b/testdata/resource-rules.yaml
@@ -16,7 +16,7 @@ rules:
     description: Parameter names must be snake_case.
     message: '{{description}}'
     severity: error
-    given: $..parameters[*]
+    given: $..parameters[?(@.in!='header')]
     then:
       field: 'name'
       function: casing

--- a/testdata/resources/projects/2021-08-20/spec.yaml
+++ b/testdata/resources/projects/2021-08-20/spec.yaml
@@ -31,6 +31,11 @@ paths:
           description: The id of the project
           schema:
             type: string
+        - name: x-private-matter
+          in: header
+          description: It's a secret to everybody
+          schema:
+            type: string
       responses:
         '400': { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/responses/400.yaml#/400' }
         '401': { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/responses/401.yaml#/401' }

--- a/vervet-underground/internal/scraper/scraper.go
+++ b/vervet-underground/internal/scraper/scraper.go
@@ -226,7 +226,7 @@ func (s *Scraper) getNewVersion(ctx context.Context, svc service, version string
 		return nil, false, errors.WithStack(err)
 	}
 	// For now, let's just see if the response can be unmarshaled
-	// TODO: Load w/kin-openapi and validate it?
+	// TODO: Load w/kin-openapi and remove excluded elements
 	var doc map[string]interface{}
 	err = json.Unmarshal(respContents, &doc)
 	if err != nil {


### PR DESCRIPTION
This will be used in Vervet Underground configuration to filter out
internal edge-proxy and API gateway elements from the public OpenAPI it
serves up.