### PR TITLE
feat: exclude elements matching patterns from VU output

### DIFF
--- a/vervet-underground/config/config.go
+++ b/vervet-underground/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"github.com/snyk/vervet/v4"
 	"github.com/spf13/viper"
 )
 
@@ -19,8 +20,18 @@ type ServerConfig struct {
 	Host     string
 	Services []string
 	Storage  StorageConfig
+	Merging  MergeConfig
 }
 
+// MergeConfig contains configuration options defining how to merge OpenAPI
+// documents when collating aggregate OpenAPI specifications across all
+// services.
+type MergeConfig struct {
+	ExcludePatterns vervet.ExcludePatterns
+}
+
+// StorageConfig defines the configuration options for storage.
+// The value of Type determines which of S3 or GCS will be used.
 type StorageConfig struct {
 	Type           StorageType
 	BucketName     string
@@ -29,6 +40,7 @@ type StorageConfig struct {
 	GCS            GcsConfig
 }
 
+// S3Config defines configuration options for AWS S3 storage.
 type S3Config struct {
 	Region     string
 	Endpoint   string
@@ -37,6 +49,7 @@ type S3Config struct {
 	SessionKey string
 }
 
+// GcsConfig defines configuration options for Google Cloud Storage (GCS).
 type GcsConfig struct {
 	Region    string
 	Endpoint  string

--- a/vervet-underground/config/config_test.go
+++ b/vervet-underground/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/snyk/vervet/v4"
 
 	"vervet-underground/config"
 )
@@ -50,6 +51,35 @@ func TestLoad(t *testing.T) {
 		expected := config.ServerConfig{
 			Host:     "0.0.0.0",
 			Services: []string{"localhost"},
+			Storage: config.StorageConfig{
+				Type: config.StorageTypeMemory,
+			},
+		}
+		c.Assert(*conf, qt.DeepEquals, expected)
+	})
+
+	c.Run("specify excludes", func(c *qt.C) {
+		f := createTestFile(c, []byte(`{
+			"merging": {
+				"excludePatterns": {
+					"extensionPatterns": "^x-snyk-.*",
+					"headerPatterns": ".*-internal$"
+				}
+			}
+		}`))
+
+		conf, err := config.Load(f.Name())
+		c.Assert(err, qt.IsNil)
+
+		expected := config.ServerConfig{
+			Host:     "localhost",
+			Services: nil,
+			Merging: config.MergeConfig{
+				ExcludePatterns: vervet.ExcludePatterns{
+					ExtensionPatterns: []string{"^x-snyk-.*"},
+					HeaderPatterns:    []string{".*-internal$"},
+				},
+			},
 			Storage: config.StorageConfig{
 				Type: config.StorageTypeMemory,
 			},

--- a/vervet-underground/go.mod
+++ b/vervet-underground/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/rs/zerolog v1.26.1
 	github.com/slok/go-http-metrics v0.10.0
-	github.com/snyk/vervet/v4 v4.15.1
+	github.com/snyk/vervet/v4 v4.19.0
 	github.com/spf13/viper v1.11.0
 	go.uber.org/multierr v1.8.0
 	google.golang.org/api v0.76.0

--- a/vervet-underground/go.sum
+++ b/vervet-underground/go.sum
@@ -489,6 +489,8 @@ github.com/slok/go-http-metrics v0.10.0 h1:rh0LaYEKza5eaYRGDXujKrOln57nHBi4TtVhm
 github.com/slok/go-http-metrics v0.10.0/go.mod h1:lFqdaS4kWMfUKCSukjC47PdCeTk+hXDUVm8kLHRqJ38=
 github.com/snyk/vervet/v4 v4.15.1 h1:Kz77gfocq/Hqb0WRrOIUb1EyV0cQsGW77xSNWwUNGlk=
 github.com/snyk/vervet/v4 v4.15.1/go.mod h1:44bzoNXULEwlfmIZh9KCrYQdjTI4LHZZNhky5IW0Jrc=
+github.com/snyk/vervet/v4 v4.19.0 h1:JnI+m979DWTXC9A8ESpWlSjF3JT6Q7SzdcCj8s2UAeU=
+github.com/snyk/vervet/v4 v4.19.0/go.mod h1:44bzoNXULEwlfmIZh9KCrYQdjTI4LHZZNhky5IW0Jrc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=
 github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfAqwo=

--- a/vervet-underground/internal/storage/collator_test.go
+++ b/vervet-underground/internal/storage/collator_test.go
@@ -12,7 +12,7 @@ import (
 	"vervet-underground/internal/storage"
 )
 
-const seriveASpec = `
+const serviceASpec = `
 openapi: 3.0.0
 info:
   title: ServiceA API
@@ -24,10 +24,11 @@ paths:
       summary: Test endpoint
       responses:
         '204':
+          x-internal: its a secret to everybody
           description: An empty response
 `
 
-const seriveBSpec = `
+const serviceBSpec = `
 openapi: 3.0.0
 info:
   title: ServiceB API
@@ -35,10 +36,12 @@ info:
 paths:
   /example:
     post:
+      x-other-internal: its a secret to everybody else
       operation: postTest
       summary: Example endpoint
       responses:
         '204':
+          x-internal: its a secret to everybody
           description: An empty response
 `
 
@@ -61,15 +64,15 @@ func TestCollator_Collate(t *testing.T) {
 	collator := storage.NewCollator()
 	collator.Add("service-a", storage.ContentRevision{
 		Version: v20220201_beta,
-		Blob:    []byte(seriveASpec),
+		Blob:    []byte(serviceASpec),
 	})
 	collator.Add("service-a", storage.ContentRevision{
 		Version: v20220301_ga,
-		Blob:    []byte(seriveASpec),
+		Blob:    []byte(serviceASpec),
 	})
 	collator.Add("service-b", storage.ContentRevision{
 		Version: v20220401_ga,
-		Blob:    []byte(seriveBSpec),
+		Blob:    []byte(serviceBSpec),
 	})
 
 	versions, specs, err := collator.Collate()
@@ -87,6 +90,41 @@ func TestCollator_Collate(t *testing.T) {
 
 	c.Assert(specs[v20220401_ga].Paths.Find("/test"), qt.IsNotNil)
 	c.Assert(specs[v20220401_ga].Paths.Find("/example"), qt.IsNotNil)
+
+	// No filtering, so extensions are all present
+	c.Assert(specs[v20220401_ga].Paths["/example"].Post.ExtensionProps.Extensions["x-other-internal"], qt.Not(qt.IsNil))
+	c.Assert(specs[v20220401_ga].Paths["/example"].Post.Responses["204"].Value.ExtensionProps.Extensions["x-internal"], qt.Not(qt.IsNil))
+}
+
+func TestCollator_Collate_ExcludePatterns(t *testing.T) {
+	c := qt.New(t)
+
+	v20220301_ga := vervet.Version{
+		Date:      time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC),
+		Stability: vervet.StabilityGA,
+	}
+	v20220401_ga := vervet.Version{
+		Date:      time.Date(2022, 4, 1, 0, 0, 0, 0, time.UTC),
+		Stability: vervet.StabilityGA,
+	}
+
+	collator := storage.NewCollatorExcludePatterns(vervet.ExcludePatterns{
+		ExtensionPatterns: []string{"^x.*-internal$"},
+	})
+
+	collator.Add("service-a", storage.ContentRevision{
+		Version: v20220301_ga,
+		Blob:    []byte(serviceASpec),
+	})
+	collator.Add("service-b", storage.ContentRevision{
+		Version: v20220401_ga,
+		Blob:    []byte(serviceBSpec),
+	})
+	_, specs, err := collator.Collate()
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(specs[v20220401_ga].Paths["/example"].Post.ExtensionProps.Extensions["x-other-internal"], qt.IsNil)
+	c.Assert(specs[v20220401_ga].Paths["/example"].Post.Responses["204"].Value.ExtensionProps.Extensions["x-internal"], qt.IsNil)
 }
 
 func TestCollator_Collate_Conflict(t *testing.T) {


### PR DESCRIPTION
This allows configuring Vervet Underground to remove elements matching
certain patterns from the collated OpenAPI output.