### PR TITLE
feat: allow extending generate templates with Go functions

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/snyk/vervet/v4/config"
 	"github.com/snyk/vervet/v4/internal/generator"
@@ -21,6 +22,7 @@ type GeneratorParams struct {
 	Debug          bool
 	DryRun         bool
 	FS             fs.FS
+	Functions      template.FuncMap
 }
 
 // Generate executes code generators against OpenAPI specs.
@@ -83,6 +85,9 @@ func Generate(params GeneratorParams) error {
 	}
 	if params.FS != nil {
 		options = append(options, generator.Filesystem(params.FS))
+	}
+	if len(params.Functions) > 0 {
+		options = append(options, generator.Functions(params.Functions))
 	}
 	generators := map[string]*generator.Generator{}
 	for k, genConf := range proj.Generators {

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 	"testing/fstest"
+	"text/template"
 
 	qt "github.com/frankban/quicktest"
 
@@ -29,6 +30,8 @@ version-readme:
 			Data: []byte(`
 This is a generated scaffold for version {{ .Version.String }} of the
 {{ .Resource }} resource in API {{ .API }}.
+
+{{ "hello" | testFunc }}
 `),
 			Mode: 0666,
 		},
@@ -40,6 +43,11 @@ This is a generated scaffold for version {{ .Version.String }} of the
 		GeneratorsFile: "/generator.yaml",
 		Generators:     []string{"version-readme"},
 		FS:             fs,
+		Functions: template.FuncMap{
+			"testFunc": func(s string) string {
+				return "j" + s[1:] + " world!"
+			},
+		},
 	}
 	err := generate.Generate(params)
 	c.Assert(err, qt.IsNil)
@@ -49,5 +57,7 @@ This is a generated scaffold for version {{ .Version.String }} of the
 	c.Assert(string(contents), qt.Equals, `
 This is a generated scaffold for version 2021-06-01~experimental of the
 hello-world resource in API testdata.
+
+jello world!
 `)
 }

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -199,6 +199,14 @@ func Filesystem(FS fs.FS) Option {
 	}
 }
 
+func Functions(funcs template.FuncMap) Option {
+	return func(g *Generator) {
+		for k := range funcs {
+			g.functions[k] = funcs[k]
+		}
+	}
+}
+
 // Execute runs the generator on the given resources.
 func (g *Generator) Execute(resources ResourceMap) ([]string, error) {
 	var allFiles []string


### PR DESCRIPTION
This leaves generate.Generate open to extension with template functions
developed in Go.

Javascript template functions with the same name will take precedence
over Go functions provided through generate.GeneratorParams.

Built-in internal generator functions take precedence over both.