### PR TITLE
fix: support instantiating a Document with an already loaded URL

### DIFF
--- a/document.go
+++ b/document.go
@@ -101,6 +101,17 @@ func NewDocumentFile(specFile string) (_ *Document, returnErr error) {
 	}, nil
 }
 
+// NewResolvedDocument returns a Document that has already been loaded and
+// references resolved from the given URL. The URL is provided to indicate the
+// document's origin in logging and error messages.
+func NewResolvedDocument(t *openapi3.T, url *url.URL) *Document {
+	return &Document{
+		T:    t,
+		path: url.String(),
+		url:  url,
+	}
+}
+
 // MarshalJSON implements json.Marshaler.
 func (d *Document) MarshalJSON() ([]byte, error) {
 	return d.T.MarshalJSON()


### PR DESCRIPTION
This adds a new Document constructor which is needed by
vervet-underground when creating Documents for collation.

The private path and url fields are used to indicate the identity of
documents in errors, necessary for logging problems with that service.

To be followed by a VU change to use the new constructor.