### PR TITLE
fix: improve logging, fix s3 crash and inappropriate loader reuse

### DIFF
--- a/vervet-underground/Dockerfile
+++ b/vervet-underground/Dockerfile
@@ -6,7 +6,7 @@ RUN go mod download
 RUN CGO_ENABLED=0 GOOS=linux go build -o server
 
 # Run
-FROM alpine:3.14
+FROM gcr.io/distroless/base-debian11
 WORKDIR /
 COPY --from=builder /src/server .
 EXPOSE 8080

--- a/vervet-underground/go.mod
+++ b/vervet-underground/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/rs/zerolog v1.26.1
 	github.com/slok/go-http-metrics v0.10.0
-	github.com/snyk/vervet/v4 v4.19.0
+	github.com/snyk/vervet/v4 v4.21.1
 	github.com/spf13/viper v1.11.0
 	go.uber.org/multierr v1.8.0
 	google.golang.org/api v0.76.0

--- a/vervet-underground/go.sum
+++ b/vervet-underground/go.sum
@@ -487,10 +487,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/slok/go-http-metrics v0.10.0 h1:rh0LaYEKza5eaYRGDXujKrOln57nHBi4TtVhmNEpbgM=
 github.com/slok/go-http-metrics v0.10.0/go.mod h1:lFqdaS4kWMfUKCSukjC47PdCeTk+hXDUVm8kLHRqJ38=
-github.com/snyk/vervet/v4 v4.15.1 h1:Kz77gfocq/Hqb0WRrOIUb1EyV0cQsGW77xSNWwUNGlk=
-github.com/snyk/vervet/v4 v4.15.1/go.mod h1:44bzoNXULEwlfmIZh9KCrYQdjTI4LHZZNhky5IW0Jrc=
-github.com/snyk/vervet/v4 v4.19.0 h1:JnI+m979DWTXC9A8ESpWlSjF3JT6Q7SzdcCj8s2UAeU=
-github.com/snyk/vervet/v4 v4.19.0/go.mod h1:44bzoNXULEwlfmIZh9KCrYQdjTI4LHZZNhky5IW0Jrc=
+github.com/snyk/vervet/v4 v4.21.1 h1:Paz3qbMT7/jrjEA2oWlSHg9/8VqA04mRZznDUyKXwCM=
+github.com/snyk/vervet/v4 v4.21.1/go.mod h1:44bzoNXULEwlfmIZh9KCrYQdjTI4LHZZNhky5IW0Jrc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=
 github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfAqwo=

--- a/vervet-underground/internal/storage/s3/client.go
+++ b/vervet-underground/internal/storage/s3/client.go
@@ -537,12 +537,20 @@ func handleAwsError(err error) error {
 		fault = apiErr.ErrorFault().String()
 	}
 	if errors.As(err, &re) {
+		resp := re.HTTPResponse()
+		var reqURL, reqMethod string
+		if resp != nil && resp.Request != nil {
+			if resp.Request.URL != nil {
+				reqURL = resp.Request.URL.String()
+			}
+			reqMethod = resp.Request.Method
+		}
 		log.Error().Err(re).
 			Str("service_request_id", re.ServiceRequestID()).
 			Int("status_code", re.HTTPStatusCode()).
 			Str("smithy_fault", fault).
-			Str("request_url", re.HTTPResponse().Request.URL.String()).
-			Str("request_method", re.HTTPResponse().Request.Method).
+			Str("request_url", reqURL).
+			Str("request_method", reqMethod).
 			Msg("S3 call failed")
 		switch re.HTTPStatusCode() {
 		case 404:


### PR DESCRIPTION
Update vervet to latest version to better log collate errors by
identifying the documents which failed to merge.

Fix a panic in the s3 client that can occur when the client fails to
connect. Found this when trying to get localstack to work.

Fix inappropriate openapi3.Loader reuse among multiple documents. The
loader is very stateful and hangs on to references. This can be the
source of hard to isolate and debug problems in collate. It's possible
(though unknowable at this point) that this may clear up strange
conflicts that shouldn't be occuring in a live deployment with the GCS
backend.