### PR TITLE
fix: separate service name from URL, collate around openapi paths

### DIFF
--- a/vervet-underground/internal/scraper/gcs_scraper_test.go
+++ b/vervet-underground/internal/scraper/gcs_scraper_test.go
@@ -92,10 +92,11 @@ func TestGCSScraper(t *testing.T) {
 	}
 
 	cfg := &config.ServerConfig{
-		Services: []string{
-			petfoodService.URL,
-			animalsService.URL,
-		},
+		Services: []config.ServiceConfig{{
+			Name: "petfood", URL: petfoodService.URL,
+		}, {
+			Name: "animals", URL: animalsService.URL,
+		}},
 	}
 
 	client, err := gcs.New(ctx, gcsCfg)
@@ -159,10 +160,11 @@ func TestGCSScraperCollation(t *testing.T) {
 	}
 
 	cfg := &config.ServerConfig{
-		Services: []string{
-			petfoodService.URL,
-			animalsService.URL,
-		},
+		Services: []config.ServiceConfig{{
+			Name: "petfood", URL: petfoodService.URL,
+		}, {
+			Name: "animals", URL: animalsService.URL,
+		}},
 	}
 
 	client, err := gcs.New(ctx, gcsCfg)

--- a/vervet-underground/internal/scraper/scraper_test.go
+++ b/vervet-underground/internal/scraper/scraper_test.go
@@ -85,17 +85,18 @@ func TestScraper(t *testing.T) {
 
 	petfoodService, animalsService := setupHttpServers(c)
 	tests := []struct {
-		service, version, digest string
+		name, version, digest string
 	}{
-		{petfoodService.URL, "2021-09-01", "sha256:I20cAQ3VEjDrY7O0B678yq+0pYN2h3sxQy7vmdlo4+w="},
-		{animalsService.URL, "2021-10-16", "sha256:P1FEFvnhtxJSqXr/p6fMNKE+HYwN6iwKccBGHIVZbyg="},
+		{"petfood", "2021-09-01", "sha256:I20cAQ3VEjDrY7O0B678yq+0pYN2h3sxQy7vmdlo4+w="},
+		{"animals", "2021-10-16", "sha256:P1FEFvnhtxJSqXr/p6fMNKE+HYwN6iwKccBGHIVZbyg="},
 	}
 
 	cfg := &config.ServerConfig{
-		Services: []string{
-			petfoodService.URL,
-			animalsService.URL,
-		},
+		Services: []config.ServiceConfig{{
+			Name: "petfood", URL: petfoodService.URL,
+		}, {
+			Name: "animals", URL: animalsService.URL,
+		}},
 	}
 	st := mem.New()
 	sc, err := scraper.New(cfg, st, scraper.Clock(func() time.Time { return t0 }))
@@ -107,7 +108,7 @@ func TestScraper(t *testing.T) {
 
 	// No version digests should be known
 	for _, test := range tests {
-		ok, err := st.HasVersion(ctx, test.service, test.version, test.digest)
+		ok, err := st.HasVersion(ctx, test.name, test.version, test.digest)
 		c.Assert(err, qt.IsNil)
 		c.Assert(ok, qt.IsFalse)
 	}
@@ -118,7 +119,7 @@ func TestScraper(t *testing.T) {
 
 	// Version digests now known to storage
 	for _, test := range tests {
-		ok, err := st.HasVersion(ctx, test.service, test.version, test.digest)
+		ok, err := st.HasVersion(ctx, test.name, test.version, test.digest)
 		c.Assert(err, qt.IsNil)
 		c.Assert(ok, qt.IsTrue)
 	}
@@ -156,7 +157,7 @@ func TestEmptyScrape(t *testing.T) {
 func TestScrapeClientError(t *testing.T) {
 	c := qt.New(t)
 	cfg := &config.ServerConfig{
-		Services: []string{"http://example.com/nope"},
+		Services: []config.ServiceConfig{{Name: "nope", URL: "http://example.com/nope"}},
 	}
 	st := mem.New()
 	sc, err := scraper.New(cfg, st,
@@ -187,17 +188,19 @@ func TestScraperCollation(t *testing.T) {
 
 	petfoodService, animalsService := setupHttpServers(c)
 	tests := []struct {
-		service, version, digest string
-	}{
-		{petfoodService.URL, "2021-09-01", "sha256:I20cAQ3VEjDrY7O0B678yq+0pYN2h3sxQy7vmdlo4+w="},
-		{animalsService.URL, "2021-10-16", "sha256:P1FEFvnhtxJSqXr/p6fMNKE+HYwN6iwKccBGHIVZbyg="},
-	}
+		name, version, digest string
+	}{{
+		"petfood", "2021-09-01", "sha256:I20cAQ3VEjDrY7O0B678yq+0pYN2h3sxQy7vmdlo4+w=",
+	}, {
+		"animals", "2021-10-16", "sha256:P1FEFvnhtxJSqXr/p6fMNKE+HYwN6iwKccBGHIVZbyg=",
+	}}
 
 	cfg := &config.ServerConfig{
-		Services: []string{
-			petfoodService.URL,
-			animalsService.URL,
-		},
+		Services: []config.ServiceConfig{{
+			Name: "petfood", URL: petfoodService.URL,
+		}, {
+			Name: "animals", URL: animalsService.URL,
+		}},
 	}
 	memSt := mem.New()
 	st, ok := memSt.(*mem.Storage)
@@ -218,7 +221,7 @@ func TestScraperCollation(t *testing.T) {
 
 	// Version digests now known to storage
 	for _, test := range tests {
-		ok, err := st.HasVersion(ctx, test.service, test.version, test.digest)
+		ok, err := st.HasVersion(ctx, test.name, test.version, test.digest)
 		c.Assert(err, qt.IsNil)
 		c.Assert(ok, qt.IsTrue)
 	}

--- a/vervet-underground/internal/storage/collator_test.go
+++ b/vervet-underground/internal/storage/collator_test.go
@@ -26,6 +26,16 @@ paths:
         '204':
           x-internal: its a secret to everybody
           description: An empty response
+  /openapi:
+    get:
+      responses:
+        '200':
+          description: List OpenAPI versions
+  /openapi/{version}:
+    get:
+      responses:
+        '200':
+          description: Get OpenAPI at version
 `
 
 const serviceBSpec = `
@@ -43,6 +53,16 @@ paths:
         '204':
           x-internal: its a secret to everybody
           description: An empty response
+  /openapi:
+    get:
+      responses:
+        '200':
+          description: List OpenAPI versions
+  /openapi/{version}:
+    get:
+      responses:
+        '200':
+          description: Get OpenAPI at version
 `
 
 func TestCollator_Collate(t *testing.T) {

--- a/vervet-underground/server.go
+++ b/vervet-underground/server.go
@@ -169,10 +169,8 @@ func logError(err error) {
 		Msg("UnhandledException")
 }
 
-func healthHandler(router *mux.Router, services []string) {
+func healthHandler(router *mux.Router, services []config.ServiceConfig) {
 	router.Path("/").Methods("GET").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(1 * time.Second)
-		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
 		encoder := json.NewEncoder(w)
 		if err := encoder.Encode(map[string]interface{}{"msg": "success", "services": services}); err != nil {


### PR DESCRIPTION
Two fixes:
- Separate the service name from the URL, so that endpoints can be
  updated without breaking historical continuity.
- Ignore /openapi endpoints during collation, if we've already merged
  these paths into the result.