### PR TITLE
fix: only collate configured services

### DIFF
--- a/vervet-underground/internal/scraper/scraper.go
+++ b/vervet-underground/internal/scraper/scraper.go
@@ -164,7 +164,11 @@ func (s *Scraper) scrape(ctx context.Context, scrapeTime time.Time, svc service)
 }
 
 func (s *Scraper) collateVersions(ctx context.Context) error {
-	return s.storage.CollateVersions(ctx)
+	services := make([]string, len(s.services))
+	for i := range s.services {
+		services[i] = s.services[i].name
+	}
+	return s.storage.CollateVersions(ctx, services...)
 }
 
 func (s *Scraper) getVersions(ctx context.Context, svc service) ([]string, error) {

--- a/vervet-underground/internal/storage/gcs/client.go
+++ b/vervet-underground/internal/storage/gcs/client.go
@@ -117,7 +117,12 @@ func (s *Storage) NotifyVersions(ctx context.Context, name string, versions []st
 
 // CollateVersions iterates over all possible permutations of Service versions
 // to create a unified version spec for each unique vervet.Version.
-func (s *Storage) CollateVersions(ctx context.Context) error {
+func (s *Storage) CollateVersions(ctx context.Context, services ...string) error {
+	servicesSet := map[string]struct{}{}
+	for i := range services {
+		servicesSet[services[i]] = struct{}{}
+	}
+
 	// create an aggregate to process collated data from storage data
 	aggregate := s.newCollator()
 	serviceRevisionResults, err := s.ListObjects(ctx, vustorage.ServiceVersionsFolder, "")
@@ -131,6 +136,10 @@ func (s *Storage) CollateVersions(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		if _, ok := servicesSet[service]; !ok {
+			continue
+		}
+
 		rev, obj, err := s.GetObjectWithMetadata(ctx, vustorage.ServiceVersionsFolder+service+"/"+version+"/"+digest+".json")
 		if err != nil {
 			return err

--- a/vervet-underground/internal/storage/mem/mem.go
+++ b/vervet-underground/internal/storage/mem/mem.go
@@ -186,10 +186,18 @@ func (s *Storage) Version(ctx context.Context, version string) ([]byte, error) {
 }
 
 // CollateVersions aggregates versions and revisions from all the services, and produces unified versions and merged specs for all APIs.
-func (s *Storage) CollateVersions(ctx context.Context) error {
+func (s *Storage) CollateVersions(ctx context.Context, services ...string) error {
+	servicesSet := map[string]struct{}{}
+	for i := range services {
+		servicesSet[services[i]] = struct{}{}
+	}
+
 	// create an aggregate to process collated data from storage data
 	aggregate := s.newCollator()
 	for serv, versions := range s.serviceVersionMappedRevisionSpecs {
+		if _, ok := servicesSet[serv]; !ok {
+			continue
+		}
 		for _, revisions := range versions {
 			for _, revision := range revisions {
 				aggregate.Add(serv, revision)

--- a/vervet-underground/internal/storage/mem/mem_test.go
+++ b/vervet-underground/internal/storage/mem/mem_test.go
@@ -71,6 +71,11 @@ func TestCollateVersions(t *testing.T) {
 
 	err = s.CollateVersions(ctx)
 	c.Assert(err, qt.IsNil)
+	_, err = s.Version(ctx, "2021-09-16")
+	c.Assert(err, qt.ErrorMatches, "no matching version")
+
+	err = s.CollateVersions(ctx, "petfood")
+	c.Assert(err, qt.IsNil)
 	before, err := s.Version(ctx, "2021-09-16")
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(before), qt.Equals, emptySpec)
@@ -81,7 +86,7 @@ func TestCollateVersions(t *testing.T) {
 
 	err = s.NotifyVersion(ctx, "petfood", "2021-09-16", []byte(spec), t0.Add(time.Second))
 	c.Assert(err, qt.IsNil)
-	err = s.CollateVersions(ctx)
+	err = s.CollateVersions(ctx, "petfood")
 	c.Assert(err, qt.IsNil)
 
 	after, err := s.Version(ctx, "2021-09-16")

--- a/vervet-underground/internal/storage/s3/client.go
+++ b/vervet-underground/internal/storage/s3/client.go
@@ -222,7 +222,12 @@ func (s *Storage) Version(ctx context.Context, version string) ([]byte, error) {
 }
 
 // CollateVersions aggregates versions and revisions from all the services, and produces unified versions and merged specs for all APIs.
-func (s *Storage) CollateVersions(ctx context.Context) error {
+func (s *Storage) CollateVersions(ctx context.Context, services ...string) error {
+	servicesSet := map[string]struct{}{}
+	for i := range services {
+		servicesSet[services[i]] = struct{}{}
+	}
+
 	// create an aggregate to process collated data from storage data
 	aggregate := s.newCollator()
 	serviceRevisionResults, err := s.ListObjects(ctx, storage.ServiceVersionsFolder, "")
@@ -236,6 +241,10 @@ func (s *Storage) CollateVersions(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		if _, ok := servicesSet[service]; !ok {
+			continue
+		}
+
 		rev, err := s.GetObjectWithMetadata(ctx, storage.ServiceVersionsFolder+service+"/"+version+"/"+digest+".json")
 		if err != nil {
 			return err

--- a/vervet-underground/internal/storage/storage.go
+++ b/vervet-underground/internal/storage/storage.go
@@ -20,9 +20,9 @@ type Storage interface {
 	NotifyVersions(ctx context.Context, name string, versions []string, scrapeTime time.Time) error
 
 	// CollateVersions tells the storage to execute the compilation and
-	// update all VU-formatted specs from all services and their
+	// update all VU-formatted specs from the given list of services and their
 	// respective versions gathered.
-	CollateVersions(ctx context.Context) error
+	CollateVersions(ctx context.Context, services ...string) error
 
 	// HasVersion returns whether the storage has already stored the service
 	// API spec version at the given content digest.


### PR DESCRIPTION
If a service is removed from configuration, stop collating it. Storage is left intact.

This fixes an issue where past service scrapes continue to show up in the collated output, even when removed from the services configuration.

The same result might be had by removing a service from config and manually deleting items from storage on deploy, but this is not a very desirable thing to do in production. It's akin to a stop-the-world manual database migration.

Stacked on #210 
Fixes #209 