### PR TITLE
fix: CollateVersions filters out old services

### DIFF
--- a/vervet-underground/config/config.go
+++ b/vervet-underground/config/config.go
@@ -25,6 +25,15 @@ type ServerConfig struct {
 	Merging  MergeConfig
 }
 
+// ServiceFilter provides a map of service names to quickly filter old services.
+func (c *ServerConfig) ServiceFilter() map[string]bool {
+	var services map[string]bool
+	for _, s := range c.Services {
+		services[s.Name] = true
+	}
+	return services
+}
+
 func (c *ServerConfig) validate() error {
 	serviceNames := map[string]struct{}{}
 	for _, svc := range c.Services {

--- a/vervet-underground/config/config.go
+++ b/vervet-underground/config/config.go
@@ -27,7 +27,7 @@ type ServerConfig struct {
 
 // ServiceFilter provides a map of service names to quickly filter old services.
 func (c *ServerConfig) ServiceFilter() map[string]bool {
-	var services map[string]bool
+	services := make(map[string]bool)
 	for _, s := range c.Services {
 		services[s.Name] = true
 	}

--- a/vervet-underground/internal/scraper/scraper.go
+++ b/vervet-underground/internal/scraper/scraper.go
@@ -22,10 +22,11 @@ import (
 // Scraper gets OpenAPI specs from a collection of services and updates storage
 // accordingly.
 type Scraper struct {
-	storage  storage.Storage
-	services []service
-	http     *http.Client
-	timeNow  func() time.Time
+	storage       storage.Storage
+	services      []service
+	http          *http.Client
+	timeNow       func() time.Time
+	serviceFilter map[string]bool
 }
 
 type service struct {
@@ -59,6 +60,7 @@ func New(cfg *config.ServerConfig, store storage.Storage, options ...Option) (*S
 func setupScraper(s *Scraper, cfg *config.ServerConfig, options []Option) error {
 	s.services = make([]service, len(cfg.Services))
 	for i := range cfg.Services {
+		s.serviceFilter[cfg.Services[i].Name] = true
 		u, err := url.Parse(cfg.Services[i].URL + "/openapi")
 		if err != nil {
 			return errors.Wrapf(err, "invalid service %q", cfg.Services[i].Name)
@@ -164,7 +166,7 @@ func (s *Scraper) scrape(ctx context.Context, scrapeTime time.Time, svc service)
 }
 
 func (s *Scraper) collateVersions(ctx context.Context) error {
-	return s.storage.CollateVersions(ctx)
+	return s.storage.CollateVersions(ctx, s.serviceFilter)
 }
 
 func (s *Scraper) getVersions(ctx context.Context, svc service) ([]string, error) {

--- a/vervet-underground/internal/scraper/scraper.go
+++ b/vervet-underground/internal/scraper/scraper.go
@@ -59,6 +59,7 @@ func New(cfg *config.ServerConfig, store storage.Storage, options ...Option) (*S
 
 func setupScraper(s *Scraper, cfg *config.ServerConfig, options []Option) error {
 	s.services = make([]service, len(cfg.Services))
+	s.serviceFilter = make(map[string]bool)
 	for i := range cfg.Services {
 		s.serviceFilter[cfg.Services[i].Name] = true
 		u, err := url.Parse(cfg.Services[i].URL + "/openapi")

--- a/vervet-underground/internal/storage/gcs/client.go
+++ b/vervet-underground/internal/storage/gcs/client.go
@@ -117,7 +117,7 @@ func (s *Storage) NotifyVersions(ctx context.Context, name string, versions []st
 
 // CollateVersions iterates over all possible permutations of Service versions
 // to create a unified version spec for each unique vervet.Version.
-func (s *Storage) CollateVersions(ctx context.Context) error {
+func (s *Storage) CollateVersions(ctx context.Context, serviceFilter map[string]bool) error {
 	// create an aggregate to process collated data from storage data
 	aggregate := s.newCollator()
 	serviceRevisionResults, err := s.ListObjects(ctx, vustorage.ServiceVersionsFolder, "")
@@ -130,6 +130,9 @@ func (s *Storage) CollateVersions(ctx context.Context) error {
 		service, version, digest, err := parseServiceVersionRevisionKey(revContent.Name)
 		if err != nil {
 			return err
+		}
+		if _, ok := serviceFilter[service]; !ok {
+			continue
 		}
 		rev, obj, err := s.GetObjectWithMetadata(ctx, vustorage.ServiceVersionsFolder+service+"/"+version+"/"+digest+".json")
 		if err != nil {

--- a/vervet-underground/internal/storage/gcs/client_test.go
+++ b/vervet-underground/internal/storage/gcs/client_test.go
@@ -154,3 +154,12 @@ func TestListObjectsAndPrefixes(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(versions, qt.Contains, "2022-02-02")
 }
+
+func TestS3StorageCollateVersion(t *testing.T) {
+	c := setup(t)
+	ctx := context.Background()
+	s, err := gcs.New(ctx, cfg)
+
+	c.Assert(err, qt.IsNil)
+	storage.AssertCollateVersion(c, s)
+}

--- a/vervet-underground/internal/storage/mem/mem.go
+++ b/vervet-underground/internal/storage/mem/mem.go
@@ -209,7 +209,6 @@ func (s *Storage) CollateVersions(ctx context.Context, serviceFilter map[string]
 	return err
 }
 
-// GetCollatedVersionSpecs
 func (s *Storage) GetCollatedVersionSpecs() (map[string][]byte, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/vervet-underground/internal/storage/mem/mem.go
+++ b/vervet-underground/internal/storage/mem/mem.go
@@ -186,10 +186,13 @@ func (s *Storage) Version(ctx context.Context, version string) ([]byte, error) {
 }
 
 // CollateVersions aggregates versions and revisions from all the services, and produces unified versions and merged specs for all APIs.
-func (s *Storage) CollateVersions(ctx context.Context) error {
+func (s *Storage) CollateVersions(ctx context.Context, serviceFilter map[string]bool) error {
 	// create an aggregate to process collated data from storage data
 	aggregate := s.newCollator()
 	for serv, versions := range s.serviceVersionMappedRevisionSpecs {
+		if _, ok := serviceFilter[serv]; !ok {
+			continue
+		}
 		for _, revisions := range versions {
 			for _, revision := range revisions {
 				aggregate.Add(serv, revision)
@@ -206,6 +209,7 @@ func (s *Storage) CollateVersions(ctx context.Context) error {
 	return err
 }
 
+// GetCollatedVersionSpecs
 func (s *Storage) GetCollatedVersionSpecs() (map[string][]byte, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/vervet-underground/internal/storage/mem/mem_test.go
+++ b/vervet-underground/internal/storage/mem/mem_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
+
+	"vervet-underground/internal/storage"
 )
 
 var t0 = time.Date(2021, time.December, 3, 20, 49, 51, 0, time.UTC)
@@ -88,4 +90,11 @@ func TestCollateVersions(t *testing.T) {
 	after, err := s.Version(ctx, "2021-09-16")
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(after), qt.Equals, spec)
+}
+
+func TestMemStorageCollateVersion(t *testing.T) {
+	s := New()
+	c := qt.New(t)
+
+	storage.AssertCollateVersion(c, s)
 }

--- a/vervet-underground/internal/storage/mem/mem_test.go
+++ b/vervet-underground/internal/storage/mem/mem_test.go
@@ -69,7 +69,8 @@ func TestCollateVersions(t *testing.T) {
 	err := s.NotifyVersion(ctx, "petfood", "2021-09-16", []byte(emptySpec), t0)
 	c.Assert(err, qt.IsNil)
 
-	err = s.CollateVersions(ctx)
+	serviceFilter := map[string]bool{"petfood": true}
+	err = s.CollateVersions(ctx, serviceFilter)
 	c.Assert(err, qt.IsNil)
 	before, err := s.Version(ctx, "2021-09-16")
 	c.Assert(err, qt.IsNil)
@@ -81,7 +82,7 @@ func TestCollateVersions(t *testing.T) {
 
 	err = s.NotifyVersion(ctx, "petfood", "2021-09-16", []byte(spec), t0.Add(time.Second))
 	c.Assert(err, qt.IsNil)
-	err = s.CollateVersions(ctx)
+	err = s.CollateVersions(ctx, serviceFilter)
 	c.Assert(err, qt.IsNil)
 
 	after, err := s.Version(ctx, "2021-09-16")

--- a/vervet-underground/internal/storage/s3/client.go
+++ b/vervet-underground/internal/storage/s3/client.go
@@ -222,7 +222,7 @@ func (s *Storage) Version(ctx context.Context, version string) ([]byte, error) {
 }
 
 // CollateVersions aggregates versions and revisions from all the services, and produces unified versions and merged specs for all APIs.
-func (s *Storage) CollateVersions(ctx context.Context) error {
+func (s *Storage) CollateVersions(ctx context.Context, serviceFilter map[string]bool) error {
 	// create an aggregate to process collated data from storage data
 	aggregate := s.newCollator()
 	serviceRevisionResults, err := s.ListObjects(ctx, storage.ServiceVersionsFolder, "")
@@ -235,6 +235,9 @@ func (s *Storage) CollateVersions(ctx context.Context) error {
 		service, version, digest, err := parseServiceVersionRevisionKey(*revContent.Key)
 		if err != nil {
 			return err
+		}
+		if _, ok := serviceFilter[service]; !ok {
+			continue
 		}
 		rev, err := s.GetObjectWithMetadata(ctx, storage.ServiceVersionsFolder+service+"/"+version+"/"+digest+".json")
 		if err != nil {

--- a/vervet-underground/internal/storage/s3/client_test.go
+++ b/vervet-underground/internal/storage/s3/client_test.go
@@ -173,3 +173,12 @@ func TestHandleAwsError(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(res), qt.Equals, "")
 }
+
+func TestS3StorageCollateVersion(t *testing.T) {
+	c := setup(t)
+	ctx := context.Background()
+	s, err := s3.New(ctx, cfg)
+
+	c.Assert(err, qt.IsNil)
+	storage.AssertCollateVersion(c, s)
+}

--- a/vervet-underground/internal/storage/storage.go
+++ b/vervet-underground/internal/storage/storage.go
@@ -22,7 +22,7 @@ type Storage interface {
 	// CollateVersions tells the storage to execute the compilation and
 	// update all VU-formatted specs from all services and their
 	// respective versions gathered.
-	CollateVersions(ctx context.Context) error
+	CollateVersions(ctx context.Context, serviceFilter map[string]bool) error
 
 	// HasVersion returns whether the storage has already stored the service
 	// API spec version at the given content digest.

--- a/vervet-underground/internal/storage/testing.go
+++ b/vervet-underground/internal/storage/testing.go
@@ -1,0 +1,34 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+var t0 = time.Date(2021, time.December, 3, 20, 49, 51, 0, time.UTC)
+
+const specPetfood = `{"components":{},"info":{"title":"ServiceA API","version":"0.0.0"},` +
+	`"openapi":"3.0.0","paths":{"/petfood":{"get":{"operation":"getTest",` +
+	`"responses":{"204":{"description":"An empty response"}},"summary":"Test endpoint"}}}}`
+
+const specAnimals = `{"components":{},"info":{"title":"ServiceA API","version":"0.0.0"},` +
+	`"openapi":"3.0.0","paths":{"/animals":{"get":{"operation":"getTest",` +
+	`"responses":{"204":{"description":"An empty response"}},"summary":"Test endpoint"}}}}`
+
+func AssertCollateVersion(c *qt.C, s Storage) {
+	ctx := context.Background()
+
+	err := s.NotifyVersion(ctx, "petfood", "2021-09-16", []byte(specPetfood), t0)
+	c.Assert(err, qt.IsNil)
+	err = s.NotifyVersion(ctx, "animals", "2021-09-16", []byte(specAnimals), t0)
+	c.Assert(err, qt.IsNil)
+
+	err = s.CollateVersions(ctx, map[string]bool{"petfood": true})
+	c.Assert(err, qt.IsNil)
+
+	after, err := s.Version(ctx, "2021-09-16")
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(after), qt.Equals, specPetfood)
+}


### PR DESCRIPTION
Previously vervet underground storage.Storage would collate versions
from all stored services, even if those services had been removed from
the configuration (e.g. because they were sunsetted).

Config now provides a ServiceFilter method which gets a filter of
current service names that is used in CollateVersions to remove any
versions from services *not* in the config, so old services are not
returned as part of the final openapi spec.