### PR TITLE
fix: merge top-level OpenAPI extensions

### DIFF
--- a/collator.go
+++ b/collator.go
@@ -228,22 +228,24 @@ func (c *Collator) Collate(rv *ResourceVersion) error {
 		return err
 	}
 
-	err = c.mergeComponents(rv)
-	if err != nil {
-		errs = multierr.Append(errs, err)
-	}
+	mergeExtensions(c.result, rv.T, false)
 	mergeInfo(c.result, rv.T, false)
-	err = c.mergePaths(rv)
-	if err != nil {
-		errs = multierr.Append(errs, err)
-	}
+	mergeOpenAPIVersion(c.result, rv.T, false)
 	mergeSecurityRequirements(c.result, rv.T, false)
 	mergeServers(c.result, rv.T, false)
-	err = c.mergeTags(rv)
-	if err != nil {
+
+	if err = c.mergeComponents(rv); err != nil {
 		errs = multierr.Append(errs, err)
 	}
-	mergeOpenAPIVersion(c.result, rv.T, false)
+
+	if err = c.mergePaths(rv); err != nil {
+		errs = multierr.Append(errs, err)
+	}
+
+	if err = c.mergeTags(rv); err != nil {
+		errs = multierr.Append(errs, err)
+	}
+
 	return errs
 }
 

--- a/testdata/merge_test_dst.yaml
+++ b/testdata/merge_test_dst.yaml
@@ -73,3 +73,6 @@ components:
      value: foo-natured
     Baz:
      value: bazil
+  x-extension:
+    key0: value0
+    key1: value1

--- a/testdata/merge_test_src.yaml
+++ b/testdata/merge_test_src.yaml
@@ -69,3 +69,6 @@ components:
      value: foo
     Bar:
      value: bar
+  x-extension:
+    key1: value11
+    key2: value2


### PR DESCRIPTION
This PR implements appropriate merge of top-level OpenAPI extensions.

`x-snyk-api-stability` seems to be a special extension that needs to be removed from the merge for the tests to pass. I'd like to get some more eyes on this.