### PR TITLE
fix: collate OpenAPI specifications without strict tag merging

### DIFF
--- a/vervet-underground/internal/storage/collator.go
+++ b/vervet-underground/internal/storage/collator.go
@@ -96,7 +96,7 @@ func (c *Collator) Collate() (vervet.VersionSlice, map[vervet.Version]openapi3.T
 }
 
 func mergeRevisions(revisions []ContentRevision) (*openapi3.T, error) {
-	collator := vervet.NewCollator()
+	collator := vervet.NewCollator(vervet.StrictTags(false))
 	var haveOpenAPI, haveOpenAPIVersion bool
 	for _, revision := range revisions {
 		loader := openapi3.NewLoader()

--- a/vervet-underground/internal/storage/collator_test.go
+++ b/vervet-underground/internal/storage/collator_test.go
@@ -17,6 +17,9 @@ openapi: 3.0.0
 info:
   title: ServiceA API
   version: 0.0.0
+tags:
+  - name: example
+    description: service a example
 paths:
   /test:
     get:
@@ -28,6 +31,8 @@ paths:
           description: An empty response
   /openapi:
     get:
+      tags:
+        - example
       responses:
         '200':
           description: List OpenAPI versions
@@ -43,9 +48,14 @@ openapi: 3.0.0
 info:
   title: ServiceB API
   version: 0.0.0
+tags:
+  - name: example
+    description: service b example
 paths:
   /example:
     post:
+      tags:
+        - example
       x-other-internal: its a secret to everybody else
       operation: postTest
       summary: Example endpoint


### PR DESCRIPTION
Allow tags to conflict when collating multiple services and let the last write win.

@migruealt This configures VU to use the StrictTags collate option we created -- we were really close to getting VU to work last week!