### PR TITLE
fix(VU): write response header after setting content-type

### DIFF
--- a/vervet-underground/server.go
+++ b/vervet-underground/server.go
@@ -191,9 +191,8 @@ func versionHandlers(ctx context.Context, router *mux.Router, sc *scraper.Scrape
 				http.Error(w, "Failure to process request", http.StatusBadRequest)
 				return
 			}
-
-			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
 			_, err = w.Write(versionSlice)
 			if err != nil {
 				logError(err)
@@ -213,9 +212,8 @@ func versionHandlers(ctx context.Context, router *mux.Router, sc *scraper.Scrape
 				http.Error(w, "Failure to process request", http.StatusBadRequest)
 				return
 			}
-
-			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
 			_, err = w.Write(bytes)
 			if err != nil {
 				logError(err)


### PR DESCRIPTION
This should fix the `text/plain` content type we were getting from VU
responses. In Go net/http, headers need to be set before writing them to
the response writer with `WriteStatus`, or they won't show up in the
response.