### PR TITLE
feat: support for excluding paths when removing elements

### DIFF
--- a/remove_elements_test.go
+++ b/remove_elements_test.go
@@ -16,6 +16,8 @@ func TestRemoveElementsExact(t *testing.T) {
 
 	// Establish that the OpenAPI document has these expected features
 
+	c.Assert(doc.Paths["/examples/hello-world"], qt.Not(qt.IsNil))
+	c.Assert(doc.Paths["/examples/hello-world/{id}"], qt.Not(qt.IsNil))
 	c.Assert(doc.Paths["/orgs/{orgId}/projects"].Get.Responses["200"].Value.Headers["snyk-request-id"], qt.Not(qt.IsNil))
 	c.Assert(doc.Paths["/orgs/{orgId}/projects"].Get.Responses["200"].Value.Headers["snyk-version-served"], qt.Not(qt.IsNil))
 	c.Assert(doc.Paths["/orgs/{org_id}/projects/{project_id}"].Delete.Parameters, qt.HasLen, 4)
@@ -29,11 +31,14 @@ func TestRemoveElementsExact(t *testing.T) {
 	err = vervet.RemoveElements(doc.T, vervet.ExcludePatterns{
 		ExtensionPatterns: []string{"x-snyk-api-releases", "x-snyk-api-resource"},
 		HeaderPatterns:    []string{"snyk-request-id", "x-private-matter"},
+		Paths:             []string{"/examples/hello-world", "/examples/hello-world/{id}"},
 	})
 	c.Assert(err, qt.IsNil)
 
 	// Assert their removal
 
+	c.Assert(doc.Paths["/examples/hello-world"], qt.IsNil)
+	c.Assert(doc.Paths["/examples/hello-world/{id}"], qt.IsNil)
 	c.Assert(doc.Paths["/orgs/{orgId}/projects"].Get.Responses["200"].Value.Headers["snyk-request-id"], qt.IsNil)             // now removed
 	c.Assert(doc.Paths["/orgs/{orgId}/projects"].Get.Responses["200"].Value.Headers["snyk-version-served"], qt.Not(qt.IsNil)) // still there
 	c.Assert(doc.Paths["/orgs/{org_id}/projects/{project_id}"].Delete.Parameters, qt.HasLen, 3)                               // x-private-matter removed


### PR DESCRIPTION
Add support to RemoveElements for removing paths.

This capability will be used for configurable path blocklists in vervet
underground.