### PR TITLE
fix(vu): use the UseFirstRoute collate option in VU collate

### DIFF
--- a/vervet-underground/go.mod
+++ b/vervet-underground/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/rs/zerolog v1.26.1
 	github.com/slok/go-http-metrics v0.10.0
-	github.com/snyk/vervet/v4 v4.25.0
+	github.com/snyk/vervet/v4 v4.25.1
 	github.com/spf13/viper v1.11.0
 	github.com/testcontainers/testcontainers-go v0.13.0
 	go.uber.org/multierr v1.8.0

--- a/vervet-underground/go.sum
+++ b/vervet-underground/go.sum
@@ -761,6 +761,8 @@ github.com/snyk/vervet/v4 v4.22.3 h1:qUmLqxwrN+oFx8xTNjHfHlgAerFV8DgW7aiuPi7wFhk
 github.com/snyk/vervet/v4 v4.22.3/go.mod h1:44bzoNXULEwlfmIZh9KCrYQdjTI4LHZZNhky5IW0Jrc=
 github.com/snyk/vervet/v4 v4.25.0 h1:2HyEqG6OuMjv38FokRdW64Z0GLWl0+fxHL7GBNrxFU8=
 github.com/snyk/vervet/v4 v4.25.0/go.mod h1:44bzoNXULEwlfmIZh9KCrYQdjTI4LHZZNhky5IW0Jrc=
+github.com/snyk/vervet/v4 v4.25.1 h1:kRefKtfE+/svGCiRZF9/XjLUpBUHMK9UdSpHVetcm/8=
+github.com/snyk/vervet/v4 v4.25.1/go.mod h1:44bzoNXULEwlfmIZh9KCrYQdjTI4LHZZNhky5IW0Jrc=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/vervet-underground/internal/storage/collator.go
+++ b/vervet-underground/internal/storage/collator.go
@@ -139,7 +139,7 @@ func (c *Collator) Collate() (vervet.VersionSlice, map[vervet.Version]openapi3.T
 }
 
 func mergeRevisions(revisions []ContentRevision) (*openapi3.T, error) {
-	collator := vervet.NewCollator(vervet.StrictTags(false))
+	collator := vervet.NewCollator(vervet.StrictTags(false), vervet.UseFirstRoute(true))
 	var haveOpenAPI, haveOpenAPIVersion bool
 	for _, revision := range revisions {
 		loader := openapi3.NewLoader()

--- a/vervet-underground/internal/storage/collator_test.go
+++ b/vervet-underground/internal/storage/collator_test.go
@@ -184,8 +184,11 @@ func TestCollator_Collate_Conflict(t *testing.T) {
 		Blob:    spec2,
 	})
 
-	_, _, err = collator.Collate()
-	c.Assert(err.Error(), qt.Contains, "conflict in #/paths /examples/hello-world")
+	_, specs, err := collator.Collate()
+	c.Assert(err, qt.IsNil)
+	// First path wins
+	c.Assert(specs[vervet.MustParseVersion("2021-06-15")].Paths["/examples/hello-world"].Post.Description,
+		qt.Equals, "Create a single result from the hello-world example - from example 1")
 }
 
 var testOverlay = `


### PR DESCRIPTION
VU wasn't using the new collate option we added -- this updates VU to
use the first instance of a path found when collating OpenAPI among all
services.

Added test coverage.