### PR TITLE
fix: filter out unexported values when using reflectwalk

### DIFF
--- a/inliner.go
+++ b/inliner.go
@@ -30,6 +30,9 @@ func (in *Inliner) Inline(doc *openapi3.T) error {
 
 // Struct implements reflectwalk.StructWalker
 func (in *Inliner) Struct(v reflect.Value) error {
+	if !v.CanInterface() {
+		return nil
+	}
 	switch val := v.Interface().(type) {
 	case openapi3.SchemaRef:
 		if _, ok := in.refs[val.Ref]; ok {
@@ -141,6 +144,9 @@ func (rr *RefRemover) RemoveRef() error {
 
 // Struct implements reflectwalk.StructWalker
 func (rr *RefRemover) Struct(v reflect.Value) error {
+	if !v.CanInterface() {
+		return nil
+	}
 	switch v.Interface().(type) {
 	case openapi3.SchemaRef:
 		valPointer := v.Addr().Interface().(*openapi3.SchemaRef)

--- a/remove_elements.go
+++ b/remove_elements.go
@@ -70,6 +70,9 @@ func (ex *excluder) apply() error {
 
 // Struct implements reflectwalk.StructWalker
 func (ex *excluder) Struct(v reflect.Value) error {
+	if !v.CanInterface() {
+		return nil
+	}
 	switch v.Interface().(type) {
 	case openapi3.ExtensionProps:
 		ex.applyExtensionProps(v.Addr().Interface().(*openapi3.ExtensionProps))


### PR DESCRIPTION
When traversing the OpenAPI document object model with reflectwalk, check whether a `reflect.Value` may be accessed with `CanInterface()` before accessing it to avoid an unexpected panic.

Fixes #241