### PR TITLE
fix: separated the lifecycle date into deprecation date and release date

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,5 @@
+package vervet
+
+// TimeNow is a patchable func pointer to obtain time.Now in the
+// version.go file, used for mocking time in tests.
+var TimeNow = &timeNow

--- a/inliner.go
+++ b/inliner.go
@@ -30,6 +30,9 @@ func (in *Inliner) Inline(doc *openapi3.T) error {
 
 // Struct implements reflectwalk.StructWalker
 func (in *Inliner) Struct(v reflect.Value) error {
+	if !v.CanInterface() {
+		return nil
+	}
 	switch val := v.Interface().(type) {
 	case openapi3.SchemaRef:
 		if _, ok := in.refs[val.Ref]; ok {
@@ -141,6 +144,9 @@ func (rr *RefRemover) RemoveRef() error {
 
 // Struct implements reflectwalk.StructWalker
 func (rr *RefRemover) Struct(v reflect.Value) error {
+	if !v.CanInterface() {
+		return nil
+	}
 	switch v.Interface().(type) {
 	case openapi3.SchemaRef:
 		valPointer := v.Addr().Interface().(*openapi3.SchemaRef)

--- a/remove_elements.go
+++ b/remove_elements.go
@@ -70,6 +70,9 @@ func (ex *excluder) apply() error {
 
 // Struct implements reflectwalk.StructWalker
 func (ex *excluder) Struct(v reflect.Value) error {
+	if !v.CanInterface() {
+		return nil
+	}
 	switch v.Interface().(type) {
 	case openapi3.ExtensionProps:
 		ex.applyExtensionProps(v.Addr().Interface().(*openapi3.ExtensionProps))


### PR DESCRIPTION
### What this does

Separates the lifecycle date into deprecation date and release date.
- For determining deprecation we use the `VERVET_LIFECYCLE_AT` env var, and if not set default to the current date.
- For determining whether a version is unreleased we always use the current date