### PR TITLE
fix: separated the lifecycle date into deprecation and release

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,5 @@
+package vervet
+
+// TimeNow is a patchable func pointer to obtain time.Now in the
+// version.go file, used for mocking time in tests.
+var TimeNow = &timeNow


### PR DESCRIPTION
### What this does
Separates the lifecycle date into two dates used for deprecation and release.

- For determining deprecation we use the `VERVET_LIFECYCLE_AT` env var, and if not set default to the current date.
- For determining whether a version is unreleased we always use the current date