### PR TITLE
fix(vu): match stability when resolving latest revision of version

### DIFF
--- a/vervet-underground/internal/storage/revision.go
+++ b/vervet-underground/internal/storage/revision.go
@@ -51,9 +51,11 @@ func (s *ServiceRevisions) Add(revision ContentRevision) {
 	sort.Sort(s.Revisions[version])
 }
 
-// ResolveLatestRevision returns the latest revision that matches the given version number. If no exact version is found,
-// it uses vervet to resolve the most recent version. When multiple revisions are found for a given version,
-// the content revision with the latest scrape timestamp is returned.
+// ResolveLatestRevision returns the latest revision that matches the given
+// version date. If no exact version is found, it uses vervet to resolve the
+// most recent version date at the same stability. When multiple revisions are
+// found for a given version, the content revision with the latest scrape
+// timestamp is returned.
 func (s ServiceRevisions) ResolveLatestRevision(version vervet.Version) (ContentRevision, error) {
 	var revision ContentRevision
 	revisions, ok := s.Revisions[version]
@@ -62,6 +64,12 @@ func (s ServiceRevisions) ResolveLatestRevision(version vervet.Version) (Content
 		if err != nil {
 			return revision, err
 		}
+		// Resolving the effective version chooses the highest stability. That
+		// works for resolving resources where a resource is only allowed one
+		// release per day. Services on the other hand, publish multiple
+		// concurrently active stabilities on a given day, so we need to
+		// override this with the stability we're looking up.
+		resolvedVersion.Stability = version.Stability
 
 		revisions, ok = s.Revisions[resolvedVersion]
 		if !ok {

--- a/vervet-underground/internal/storage/revision_test.go
+++ b/vervet-underground/internal/storage/revision_test.go
@@ -25,13 +25,18 @@ func TestServiceRevisions_ResolveLatestRevision(t *testing.T) {
 		Date:      time.Date(2022, 4, 1, 0, 0, 0, 0, time.UTC),
 		Stability: vervet.StabilityGA,
 	}
+	v20220401_beta := vervet.Version{
+		Date:      time.Date(2022, 4, 1, 0, 0, 0, 0, time.UTC),
+		Stability: vervet.StabilityBeta,
+	}
 
 	ut := storage.NewServiceRevisions()
-	ut.Add(storage.ContentRevision{Version: v20220301_ga, Digest: "0301_0", Timestamp: time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC)})
-	ut.Add(storage.ContentRevision{Version: v20220301_ga, Digest: "0301_1", Timestamp: time.Date(2022, 3, 1, 12, 0, 0, 0, time.UTC)})
-	ut.Add(storage.ContentRevision{Version: v20220301_ga, Digest: "0301_2", Timestamp: time.Date(2022, 3, 4, 0, 0, 0, 0, time.UTC)})
-	ut.Add(storage.ContentRevision{Version: v20220315_beta, Digest: "0315_0", Timestamp: time.Date(2022, 3, 15, 0, 0, 0, 0, time.UTC)})
-	ut.Add(storage.ContentRevision{Version: v20220401_ga, Digest: "0401_0"})
+	ut.Add(storage.ContentRevision{Version: v20220301_ga, Digest: "0301ga_0", Timestamp: time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC)})
+	ut.Add(storage.ContentRevision{Version: v20220301_ga, Digest: "0301ga_1", Timestamp: time.Date(2022, 3, 1, 12, 0, 0, 0, time.UTC)})
+	ut.Add(storage.ContentRevision{Version: v20220301_ga, Digest: "0301ga_2", Timestamp: time.Date(2022, 3, 4, 0, 0, 0, 0, time.UTC)})
+	ut.Add(storage.ContentRevision{Version: v20220315_beta, Digest: "0315beta_0", Timestamp: time.Date(2022, 3, 15, 0, 0, 0, 0, time.UTC)})
+	ut.Add(storage.ContentRevision{Version: v20220401_ga, Digest: "0401ga_0"})
+	ut.Add(storage.ContentRevision{Version: v20220401_beta, Digest: "0401beta_0"})
 
 	tcs := []struct {
 		version        string
@@ -40,31 +45,35 @@ func TestServiceRevisions_ResolveLatestRevision(t *testing.T) {
 	}{
 		{
 			version:        "2022-03-01",
-			expectedDigest: "0301_2",
+			expectedDigest: "0301ga_2",
 		},
 		{
-			version:        "2022-03-01~beta",
-			expectedDigest: "0301_2",
+			version:     "2022-03-01~beta",
+			expectedErr: "no revision found for resolved version: 2022-03-01~beta",
 		},
 		{
 			version:        "2022-03-05",
-			expectedDigest: "0301_2",
+			expectedDigest: "0301ga_2",
 		},
 		{
 			version:        "2022-03-15",
-			expectedDigest: "0301_2",
+			expectedDigest: "0301ga_2",
 		},
 		{
 			version:        "2022-03-15~beta",
-			expectedDigest: "0315_0",
+			expectedDigest: "0315beta_0",
 		},
 		{
 			version:        "2022-04-01",
-			expectedDigest: "0401_0",
+			expectedDigest: "0401ga_0",
 		},
 		{
 			version:        "2022-04-05~beta",
-			expectedDigest: "0401_0",
+			expectedDigest: "0401beta_0",
+		},
+		{
+			version:     "2022-04-05~experimental",
+			expectedErr: "no revision found for resolved version: 2022-04-01~experimental",
 		},
 		{
 			version:     "2020-01-01",
@@ -75,16 +84,16 @@ func TestServiceRevisions_ResolveLatestRevision(t *testing.T) {
 	for _, tc := range tcs {
 		c.Run("version "+tc.version, func(c *qt.C) {
 			version, err := vervet.ParseVersion(tc.version)
-			c.Assert(err, qt.IsNil)
+			c.Check(err, qt.IsNil)
 
 			revision, err := ut.ResolveLatestRevision(version)
 			if tc.expectedErr != "" {
-				c.Assert(err, qt.ErrorMatches, tc.expectedErr)
+				c.Check(err, qt.ErrorMatches, tc.expectedErr)
 				return
 			}
 
-			c.Assert(err, qt.IsNil)
-			c.Assert(revision.Digest, qt.Equals, tc.expectedDigest)
+			c.Check(err, qt.IsNil)
+			c.Check(revision.Digest, qt.Equals, tc.expectedDigest)
 		})
 	}
 }


### PR DESCRIPTION
The rules for resolving versions across services to collate a SaaS is slightly different from resolving versions across resources to collate a service.

vervet.VersionSlice.Resolve will resolve the greatest effective stability on a version date, which is appropriate for API consumers and collating within a service. This works because a given resource may only have one release on a given day, due to the way OpenAPI specs are organized into per-day folders.

At the SaaS level, each service may have concurrent stability versions active at each version date. Therefore when resolving the latest version, the stability searched for should be matched exactly rather than used as a lower bound for a range search.