### PR TITLE
fix: resolve OpenAPI validators at the correct stability level

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -3,3 +3,7 @@ package vervet
 // TimeNow is a patchable func pointer to obtain time.Now in the
 // version.go file, used for mocking time in tests.
 var TimeNow = &timeNow
+
+func (vi *VersionIndex) ResolveForBuild(v Version) (Version, error) {
+	return vi.resolveForBuild(v)
+}

--- a/resource_test.go
+++ b/resource_test.go
@@ -15,7 +15,7 @@ func TestResource(t *testing.T) {
 	c := qt.New(t)
 	eps, err := LoadResourceVersions(testdata.Path("resources/_examples/hello-world"))
 	c.Assert(err, qt.IsNil)
-	c.Assert(eps.Versions(), qt.DeepEquals, []Version{{
+	c.Assert(eps.Versions(), qt.DeepEquals, VersionSlice{{
 		Date:      time.Date(2021, time.June, 1, 0, 0, 0, 0, time.UTC),
 		Stability: StabilityExperimental,
 	}, {

--- a/spec_test.go
+++ b/spec_test.go
@@ -72,7 +72,7 @@ func TestSpecs(t *testing.T) {
 		}},
 	}, {
 		query: "2021-07-01~wip",
-		err:   "no matching version",
+		match: "2021-06-13~experimental",
 	}, {
 		query: "2021-06-01",
 		err:   "no matching version",

--- a/versionware/validator_resolve_test.go
+++ b/versionware/validator_resolve_test.go
@@ -1,0 +1,139 @@
+package versionware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func TestResolveStability(t *testing.T) {
+	c := qt.New(t)
+	v2022_07_10_beta := parseOpenAPI(c, `
+openapi: 3.0.0
+x-snyk-api-version: 2022-07-10~beta
+info:
+  title: 'test'
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      parameters:
+        - in: query
+          name: version
+          schema:
+            type: string
+          required: true
+        - in: query
+          name: color
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+`)
+	v2022_07_20_ga := parseOpenAPI(c, `
+openapi: 3.0.0
+x-snyk-api-version: 2022-07-20~ga
+info:
+  title: 'test'
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      parameters:
+        - in: query
+          name: version
+          schema:
+            type: string
+          required: true
+        - in: query
+          name: flavor
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+`)
+
+	v, err := NewValidator(nil, v2022_07_10_beta, v2022_07_20_ga)
+	c.Assert(err, qt.IsNil)
+	h := v.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("{}"))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	tests := []struct {
+		desc   string
+		url    string
+		status int
+	}{{
+		desc:   "valid request, version resolves to 2022-07-10~beta",
+		url:    "/foo?color=red&version=2022-07-19~beta",
+		status: 200,
+	}, {
+		desc:   "invalid request, version resolves to 2022-07-10~beta",
+		url:    "/foo?flavor=blue&version=2022-07-19~beta",
+		status: 400,
+	}, {
+		desc:   "valid request, version resolves to 2022-07-20~ga",
+		url:    "/foo?flavor=flav&version=2022-07-20",
+		status: 200,
+	}, {
+		desc:   "valid request, version resolves to 2022-07-20~ga",
+		url:    "/foo?flavor=flav&version=2022-07-21",
+		status: 200,
+	}, {
+		desc:   "invalid request, version resolves to 2022-07-10~beta",
+		url:    "/foo?flavor=flav&version=2022-07-21~beta",
+		status: 400,
+	}, {
+		desc:   "valid request, version resolves to 2022-07-10~beta",
+		url:    "/foo?color=octarine&version=2022-07-21~beta",
+		status: 200,
+	}, {
+		desc:   "invalid request, version resolves to 2022-07-20~ga",
+		url:    "/foo?color=red&version=2022-07-21~ga",
+		status: 400,
+	}, {
+		desc:   "valid request, version resolves to 2022-07-10~beta",
+		url:    "/foo?color=red&version=2022-07-20~beta",
+		status: 200,
+	}, {
+		desc:   "valid request, version resolves to expected validator",
+		url:    "/foo?flavor=flav&version=2022-07-21",
+		status: 200,
+	}, {
+		desc:   "version does not resolve, no such version",
+		url:    "/foo?version=2022-01-01",
+		status: 404,
+	}}
+
+	for i, test := range tests {
+		c.Run(fmt.Sprintf("test %d", i), func(c *qt.C) {
+			req := httptest.NewRequest("GET", test.url, nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			resp := w.Result()
+			c.Check(resp.StatusCode, qt.Equals, test.status, qt.Commentf("%s %s", test.desc, test.url))
+		})
+	}
+}
+
+func parseOpenAPI(c *qt.C, docstr string) *openapi3.T {
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(docstr))
+	c.Assert(err, qt.IsNil)
+	return doc
+}


### PR DESCRIPTION
Related to snyk/vervet#248, a similar stability version issue affects
validation middleware "versionware".

This breaking change replaces VersionSlice.Resolve with
VersionIndex.Resolve.

It turns out resolving versions correctly across date and stability
requires tracking the most recent release per stability for each
distinct version date. This requires a different structure for indexing;
a simple []Version slice does not suffice for an O(logN) search
complexity.

Fixes #250.