### PR TITLE
fix: disable lint config parsing when lint disabled

### DIFF
--- a/internal/cmd/compiler.go
+++ b/internal/cmd/compiler.go
@@ -42,7 +42,11 @@ func Build(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return runCompiler(ctx, project, ctx.Bool("lint"), true)
+	comp, err := compiler.New(ctx.Context, project, ctx.Bool("lint"))
+	if err != nil {
+		return err
+	}
+	return comp.BuildAll(ctx.Context)
 }
 
 // LintCommand is the `vervet lint` subcommand.
@@ -126,30 +130,4 @@ func projectFromContext(ctx *cli.Context) (*config.Project, error) {
 		}
 	}
 	return project, nil
-}
-
-func runCompiler(ctx *cli.Context, project *config.Project, lint, build bool) error {
-	comp, err := compiler.New(ctx.Context, project)
-	if err != nil {
-		return err
-	}
-	if lint {
-		err = comp.LintResourcesAll(ctx.Context)
-		if err != nil {
-			return err
-		}
-	}
-	if build {
-		err = comp.BuildAll(ctx.Context)
-		if err != nil {
-			return err
-		}
-	}
-	if lint {
-		err = comp.LintOutputAll(ctx.Context)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
When lint flag is set to false, the lint configuration is still parsed and vetted. In the case of sweater-comb configured with the original branch, this causes an issue when the .git directory is not there, for instance when building in Docker ignoring .git dir, terminating the command execution.

This change removes totally linters configuration when lint flag is set to false.