### PR TITLE
fix: make order of apis in generated catalog-info stable

### DIFF
--- a/internal/cmd/backstage.go
+++ b/internal/cmd/backstage.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 
 	"github.com/urfave/cli/v2"
 
@@ -156,7 +157,17 @@ func processCatalog(ctx *cli.Context, w io.Writer) error {
 			return true
 		}
 	}
-	for _, apiConf := range proj.APIs {
+
+	// range over maps does not specify order and is not guaranteed to be the
+	// same from one iteration to the next, stability is important when
+	// generating catalog-info to produce reproducible results
+	var apiNames []string
+	for k := range proj.APIs {
+		apiNames = append(apiNames, k)
+	}
+	sort.Strings(apiNames)
+	for _, apiName := range apiNames {
+		apiConf := proj.APIs[apiName]
 		outputPaths := apiConf.Output.ResolvePaths()
 		for _, outputPath := range outputPaths {
 			outputPath = filepath.Join(projectDir, outputPath)


### PR DESCRIPTION
We need to make sure that we always produce a reproducible output when generating catalog-info.yaml, it should be a pure function of the vervet config and open api specs.

We are unmarshalling the vervet config into a go map then iterating over that. Go randomises the order of values in a map so if a project declares multiple apis in a vervet config then the order of the resulting api objects in the catalog-info would be random. The only way to get stability is to use an external ordered structure, in this case we can use a string slice of the keys.