### PR TITLE
chore: change codeowners to Access

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/elk
+* @snyk/access


### PR DESCRIPTION
Moving to Access as Elk is disbanding