### PR TITLE
fix(build): disable dynamic linking by setting CGO_ENABLED=0

### DIFF
--- a/scripts/dist.bash
+++ b/scripts/dist.bash
@@ -20,10 +20,10 @@ mkdir -p ./dist/bin
 go generate ./internal/cmd/...
 
 for GOOS in linux darwin; do
-    GOOS=$GOOS GOARCH=amd64 go build -a -o ./dist/bin/vervet-$GOOS-x64 ./cmd/vervet
-    GOOS=$GOOS GOARCH=arm64 go build -a -o ./dist/bin/vervet-$GOOS-arm64 ./cmd/vervet
+    CGO_ENABLED=0 GOOS=$GOOS GOARCH=amd64 go build -a -o ./dist/bin/vervet-$GOOS-x64 ./cmd/vervet
+    CGO_ENABLED=0 GOOS=$GOOS GOARCH=arm64 go build -a -o ./dist/bin/vervet-$GOOS-arm64 ./cmd/vervet
 done
-GOOS=windows GOARCH=amd64 go build -a -o ./dist/bin/vervet.exe ./cmd/vervet
+CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -a -o ./dist/bin/vervet.exe ./cmd/vervet
 
 cp packaging/npm/passthrough.js dist/bin/vervet
 cp README.md LICENSE ATTRIBUTIONS dist/

--- a/vervet-underground/Makefile
+++ b/vervet-underground/Makefile
@@ -1,7 +1,3 @@
-GOMOD=go mod
-GOBUILD=go build
-GOTEST=go test
-
 .PHONY: fmt
 fmt:
 	go fmt ./...
@@ -20,7 +16,7 @@ lint-docker:
 
 .PHONY: tidy
 tidy:
-	$(GOMOD) tidy -v
+	go build tidy -v
 
 .PHONY: test
 test:


### PR DESCRIPTION
Disables dynamic linking (CGO_ENABLED=0) when building vervet binaries in CI to remove linking issues in the OS the binaries are executed.