### PR TITLE
fix: component extension merge

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -58,6 +58,9 @@ func mergeTags(dst, src *openapi3.T, replace bool) {
 }
 
 func initDestinationComponents(dst, src *openapi3.T) {
+	if src.Components.Extensions != nil && dst.Components.Extensions == nil {
+		dst.Components.Extensions = make(map[string]interface{})
+	}
 	if src.Components.Schemas != nil && dst.Components.Schemas == nil {
 		dst.Components.Schemas = make(map[string]*openapi3.SchemaRef)
 	}

--- a/merge_test.go
+++ b/merge_test.go
@@ -30,6 +30,10 @@ func TestMergeComponents(t *testing.T) {
 		dst := mustLoadFile(c, "merge_test_dst.yaml")
 		vervet.Merge(dst, src, false)
 
+		c.Assert(dst.Components.Extensions["x-snyk-extension-0"], openapiCmp, dstOrig.Components.Extensions["x-snyk-extension-0"])
+		c.Assert(dst.Components.Extensions["x-snyk-extension-1"], openapiCmp, dstOrig.Components.Extensions["x-snyk-extension-1"])
+		c.Assert(dst.Components.Extensions["x-snyk-extension-2"], openapiCmp, src.Components.Extensions["x-snyk-extension-2"])
+
 		c.Assert(dst.Components.Schemas["Foo"], openapiCmp, dstOrig.Components.Schemas["Foo"])
 		c.Assert(dst.Components.Schemas["Bar"], openapiCmp, src.Components.Schemas["Bar"])
 		c.Assert(dst.Components.Schemas["Baz"], openapiCmp, dstOrig.Components.Schemas["Baz"])
@@ -66,6 +70,10 @@ func TestMergeComponents(t *testing.T) {
 		dst := mustLoadFile(c, "merge_test_dst.yaml")
 		vervet.Merge(dst, src, true)
 
+		c.Assert(dst.Components.Extensions["x-snyk-extension-0"], openapiCmp, dstOrig.Components.Extensions["x-snyk-extension-0"])
+		c.Assert(dst.Components.Extensions["x-snyk-extension-1"], openapiCmp, src.Components.Extensions["x-snyk-extension-1"])
+		c.Assert(dst.Components.Extensions["x-snyk-extension-2"], openapiCmp, src.Components.Extensions["x-snyk-extension-2"])
+
 		c.Assert(dst.Components.Schemas["Foo"], openapiCmp, src.Components.Schemas["Foo"])
 		c.Assert(dst.Components.Schemas["Bar"], openapiCmp, src.Components.Schemas["Bar"])
 		c.Assert(dst.Components.Schemas["Baz"], openapiCmp, dstOrig.Components.Schemas["Baz"])
@@ -101,6 +109,10 @@ func TestMergeComponents(t *testing.T) {
 		dstOrig := mustLoadFile(c, "merge_test_dst_missing_components.yaml")
 		dst := mustLoadFile(c, "merge_test_dst_missing_components.yaml")
 		vervet.Merge(dst, src, true)
+
+		c.Assert(dst.Components.Extensions["x-snyk-extension-0"], openapiCmp, dstOrig.Components.Extensions["x-snyk-extension-0"])
+		c.Assert(dst.Components.Extensions["x-snyk-extension-1"], openapiCmp, src.Components.Extensions["x-snyk-extension-1"])
+		c.Assert(dst.Components.Extensions["x-snyk-extension-2"], openapiCmp, src.Components.Extensions["x-snyk-extension-2"])
 
 		c.Assert(dst.Components.Schemas["Foo"], openapiCmp, src.Components.Schemas["Foo"])
 		c.Assert(dst.Components.Schemas["Bar"], openapiCmp, src.Components.Schemas["Bar"])

--- a/testdata/merge_test_dst.yaml
+++ b/testdata/merge_test_dst.yaml
@@ -1,4 +1,6 @@
 components:
+  x-snyk-extension-0: "extension-0"
+  x-snyk-extension-1: "extension-1"
   schemas:
     Foo:
       type: object
@@ -73,6 +75,3 @@ components:
      value: foo-natured
     Baz:
      value: bazil
-  x-extension:
-    key0: value0
-    key1: value1

--- a/testdata/merge_test_src.yaml
+++ b/testdata/merge_test_src.yaml
@@ -1,4 +1,6 @@
 components:
+  x-snyk-extension-1: "extension-11"
+  x-snyk-extension-2: "extension-2"
   schemas:
     Foo:
       type: object
@@ -69,6 +71,3 @@ components:
      value: foo
     Bar:
      value: bar
-  x-extension:
-    key1: value11
-    key2: value2


### PR DESCRIPTION
PR #269 introduces a bug with the upgrade of kin-openapi. Component extensions are not correctly identified and considered as part of merging specs. However, a nil pointer exception can occur when no extensions are specified as part of a spec.

This PR correctly handles this nil pointer and add tests to validate behaviour.