### PR TITLE
fix: stop merging component extensions

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -58,9 +58,6 @@ func mergeTags(dst, src *openapi3.T, replace bool) {
 }
 
 func initDestinationComponents(dst, src *openapi3.T) {
-	if src.Components.Extensions != nil && dst.Components.Extensions == nil {
-		dst.Components.Extensions = make(map[string]interface{})
-	}
 	if src.Components.Schemas != nil && dst.Components.Schemas == nil {
 		dst.Components.Schemas = make(map[string]*openapi3.SchemaRef)
 	}

--- a/merge.go
+++ b/merge.go
@@ -98,7 +98,6 @@ func mergeComponents(dst, src *openapi3.T, replace bool) {
 
 	initDestinationComponents(dst, src)
 
-	mergeMap(dst.Components.Extensions, src.Components.Extensions, replace)
 	mergeMap(dst.Components.Schemas, src.Components.Schemas, replace)
 	mergeMap(dst.Components.Parameters, src.Components.Parameters, replace)
 	mergeMap(dst.Components.Headers, src.Components.Headers, replace)

--- a/merge_test.go
+++ b/merge_test.go
@@ -30,10 +30,6 @@ func TestMergeComponents(t *testing.T) {
 		dst := mustLoadFile(c, "merge_test_dst.yaml")
 		vervet.Merge(dst, src, false)
 
-		c.Assert(dst.Components.Extensions["x-snyk-extension-0"], openapiCmp, dstOrig.Components.Extensions["x-snyk-extension-0"])
-		c.Assert(dst.Components.Extensions["x-snyk-extension-1"], openapiCmp, dstOrig.Components.Extensions["x-snyk-extension-1"])
-		c.Assert(dst.Components.Extensions["x-snyk-extension-2"], openapiCmp, src.Components.Extensions["x-snyk-extension-2"])
-
 		c.Assert(dst.Components.Schemas["Foo"], openapiCmp, dstOrig.Components.Schemas["Foo"])
 		c.Assert(dst.Components.Schemas["Bar"], openapiCmp, src.Components.Schemas["Bar"])
 		c.Assert(dst.Components.Schemas["Baz"], openapiCmp, dstOrig.Components.Schemas["Baz"])
@@ -70,10 +66,6 @@ func TestMergeComponents(t *testing.T) {
 		dst := mustLoadFile(c, "merge_test_dst.yaml")
 		vervet.Merge(dst, src, true)
 
-		c.Assert(dst.Components.Extensions["x-snyk-extension-0"], openapiCmp, dstOrig.Components.Extensions["x-snyk-extension-0"])
-		c.Assert(dst.Components.Extensions["x-snyk-extension-1"], openapiCmp, src.Components.Extensions["x-snyk-extension-1"])
-		c.Assert(dst.Components.Extensions["x-snyk-extension-2"], openapiCmp, src.Components.Extensions["x-snyk-extension-2"])
-
 		c.Assert(dst.Components.Schemas["Foo"], openapiCmp, src.Components.Schemas["Foo"])
 		c.Assert(dst.Components.Schemas["Bar"], openapiCmp, src.Components.Schemas["Bar"])
 		c.Assert(dst.Components.Schemas["Baz"], openapiCmp, dstOrig.Components.Schemas["Baz"])
@@ -109,10 +101,6 @@ func TestMergeComponents(t *testing.T) {
 		dstOrig := mustLoadFile(c, "merge_test_dst_missing_components.yaml")
 		dst := mustLoadFile(c, "merge_test_dst_missing_components.yaml")
 		vervet.Merge(dst, src, true)
-
-		c.Assert(dst.Components.Extensions["x-snyk-extension-0"], openapiCmp, dstOrig.Components.Extensions["x-snyk-extension-0"])
-		c.Assert(dst.Components.Extensions["x-snyk-extension-1"], openapiCmp, src.Components.Extensions["x-snyk-extension-1"])
-		c.Assert(dst.Components.Extensions["x-snyk-extension-2"], openapiCmp, src.Components.Extensions["x-snyk-extension-2"])
 
 		c.Assert(dst.Components.Schemas["Foo"], openapiCmp, src.Components.Schemas["Foo"])
 		c.Assert(dst.Components.Schemas["Bar"], openapiCmp, src.Components.Schemas["Bar"])

--- a/merge_test.go
+++ b/merge_test.go
@@ -57,8 +57,6 @@ func TestMergeComponents(t *testing.T) {
 		c.Assert(dst.Components.Examples["Foo"], openapiCmp, dstOrig.Components.Examples["Foo"])
 		c.Assert(dst.Components.Examples["Bar"], openapiCmp, src.Components.Examples["Bar"])
 		c.Assert(dst.Components.Examples["Baz"], openapiCmp, dstOrig.Components.Examples["Baz"])
-
-		c.Assert(dst.Components.Extensions["x-extension"], qt.DeepEquals, dstOrig.Components.Extensions["x-extension"])
 	})
 	c.Run("component with replace", func(c *qt.C) {
 		src := mustLoadFile(c, "merge_test_src.yaml")
@@ -93,8 +91,6 @@ func TestMergeComponents(t *testing.T) {
 		c.Assert(dst.Components.Examples["Foo"], openapiCmp, src.Components.Examples["Foo"])
 		c.Assert(dst.Components.Examples["Bar"], openapiCmp, src.Components.Examples["Bar"])
 		c.Assert(dst.Components.Examples["Baz"], openapiCmp, dstOrig.Components.Examples["Baz"])
-
-		c.Assert(dst.Components.Extensions["x-extension"], openapiCmp, src.Components.Extensions["x-extension"])
 	})
 	c.Run("component with missing sections", func(c *qt.C) {
 		src := mustLoadFile(c, "merge_test_src.yaml")
@@ -129,8 +125,6 @@ func TestMergeComponents(t *testing.T) {
 		c.Assert(dst.Components.Examples["Foo"], openapiCmp, src.Components.Examples["Foo"])
 		c.Assert(dst.Components.Examples["Bar"], openapiCmp, src.Components.Examples["Bar"])
 		c.Assert(dst.Components.Examples["Baz"], openapiCmp, dstOrig.Components.Examples["Baz"])
-
-		c.Assert(dst.Components.Extensions["x-extension"], openapiCmp, src.Components.Extensions["x-extension"])
 	})
 }
 

--- a/testdata/merge_test_dst.yaml
+++ b/testdata/merge_test_dst.yaml
@@ -73,6 +73,3 @@ components:
      value: foo-natured
     Baz:
      value: bazil
-  x-extension:
-    key0: value0
-    key1: value1

--- a/testdata/merge_test_dst.yaml
+++ b/testdata/merge_test_dst.yaml
@@ -1,6 +1,4 @@
 components:
-  x-snyk-extension-0: "extension-0"
-  x-snyk-extension-1: "extension-1"
   schemas:
     Foo:
       type: object
@@ -75,3 +73,6 @@ components:
      value: foo-natured
     Baz:
      value: bazil
+  x-extension:
+    key0: value0
+    key1: value1

--- a/testdata/merge_test_src.yaml
+++ b/testdata/merge_test_src.yaml
@@ -1,6 +1,4 @@
 components:
-  x-snyk-extension-1: "extension-11"
-  x-snyk-extension-2: "extension-2"
   schemas:
     Foo:
       type: object
@@ -71,3 +69,6 @@ components:
      value: foo
     Bar:
      value: bar
+  x-extension:
+    key1: value11
+    key2: value2

--- a/testdata/merge_test_src.yaml
+++ b/testdata/merge_test_src.yaml
@@ -69,6 +69,3 @@ components:
      value: foo
     Bar:
      value: bar
-  x-extension:
-    key1: value11
-    key2: value2

--- a/versionware/example/releases/embed.go
+++ b/versionware/example/releases/embed.go
@@ -4,12 +4,11 @@ import "embed"
 
 // Embed compiled OpenAPI specs in Go projects.
 
-// Versions contains OpenAPI specs for each distinct release version.
-//
 //go:embed 2021-11-01~experimental/spec.json
 //go:embed 2021-11-01~experimental/spec.yaml
 //go:embed 2021-11-08~experimental/spec.json
 //go:embed 2021-11-08~experimental/spec.yaml
 //go:embed 2021-11-20~experimental/spec.json
 //go:embed 2021-11-20~experimental/spec.yaml
+// Versions contains OpenAPI specs for each distinct release version.
 var Versions embed.FS


### PR DESCRIPTION
Before bumping kin-openapi, component extensions were not actually
merged, even if the tests pretend they were.

After bumping kin-openapi, I've added the behaviour of merging component
extensions which was a mistake as it modifies the behaviour of component
generation.

This is reverting this behaviour.