### PR TITLE
chore: update nix dependencies hash

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@ buildGoModule rec {
   version = builtins.substring 0 8 lastMod;
   src = ./.;
 
-  vendorSha256 = "sha256-J1WJNDy9sMwiF2aMHlO6No1kCjEhWPbDjDqXo3dDRCk=";
+  vendorSha256 = "sha256-uDM4svFIGn3kS0ygA6aDCDI8OVCrxzHmLkc+6XWdKB4=";
 
   meta = with lib; {
     description = "API resource versioning tool";


### PR DESCRIPTION
Nix keeps a hash of go dependencies so that builds are guaranteed to be reproducible. Since the dependencies were changed since the last time the hash was updated, we also need to update the hash.