### PR TITLE
fix: pick newer versions of endpoints when collating over services

### DIFF
--- a/internal/cmd/compiler_test.go
+++ b/internal/cmd/compiler_test.go
@@ -46,6 +46,13 @@ func TestBuild(t *testing.T) {
 	}
 }
 
+func TestBuildConflict(t *testing.T) {
+	c := qt.New(t)
+	dstDir := c.TempDir()
+	err := cmd.Vervet.Run([]string{"vervet", "build", testdata.Path("conflict"), dstDir})
+	c.Assert(err, qt.ErrorMatches, `failed to load spec versions: conflict: .*`)
+}
+
 func TestBuildInclude(t *testing.T) {
 	c := qt.New(t)
 	dstDir := c.TempDir()
@@ -82,11 +89,4 @@ func TestBuildInclude(t *testing.T) {
 
 		c.Assert(expected, qt.JSONEquals, doc)
 	}
-}
-
-func TestBuildConflict(t *testing.T) {
-	c := qt.New(t)
-	dstDir := c.TempDir()
-	err := cmd.Vervet.Run([]string{"vervet", "build", testdata.Path("conflict"), dstDir})
-	c.Assert(err, qt.ErrorMatches, `failed to load spec versions: conflict: .*`)
 }

--- a/testdata/competing-specs/projects/2021-08-20/spec.yaml
+++ b/testdata/competing-specs/projects/2021-08-20/spec.yaml
@@ -1,0 +1,49 @@
+openapi: 3.0.3
+x-snyk-api-stability: experimental
+info:
+  title: Registry
+  version: 3.0.0
+servers:
+  - url: /api/v3
+    description: Snyk Registry
+tags:
+  - name: Projects
+    description: Projects
+  - name: Something
+    description: Something
+paths:
+  /orgs/{org_id}/projects/{project_id}:
+    delete:
+      tags: ["Projects"]
+      description: Delete an organization's project.
+      operationId: deleteOrgsProject
+      parameters:
+        - { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/parameters/version.yaml#/Version' }
+        - name: org_id
+          in: path
+          required: true
+          description: The id of the org containing the project
+          schema:
+            type: string
+        - name: project_id
+          in: path
+          required: true
+          description: The id of the project
+          schema:
+            type: string
+        - name: x-private-matter
+          in: header
+          description: It's a secret to everybody
+          schema:
+            type: string
+      responses:
+        '400': { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/responses/400.yaml#/400' }
+        '401': { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/responses/401.yaml#/401' }
+        '404': { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/responses/404.yaml#/404' }
+        '500': { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/responses/500.yaml#/500' }
+        '204':
+          description: 'Project was deleted'
+          headers:
+            snyk-version-requested: { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/headers/headers.yaml#/VersionRequestedResponseHeader' }
+            snyk-version-served: { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/headers/headers.yaml#/VersionServedResponseHeader' }
+            snyk-request-id: { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/headers/headers.yaml#/RequestIdResponseHeader' }

--- a/testdata/competing-specs/special_projects/2023-03-13/spec.yaml
+++ b/testdata/competing-specs/special_projects/2023-03-13/spec.yaml
@@ -1,0 +1,58 @@
+openapi: 3.0.3
+x-snyk-api-stability: experimental
+info:
+  title: Registry
+  version: 3.0.0
+servers:
+  - url: /api/v3
+    description: Snyk Registry
+tags:
+  - name: Special Projects
+    description: Special Projects
+paths:
+  /orgs/{org_id}/projects/{project_id}:
+    delete:
+      tags: ["Special Projects"]
+      description: Delete an organization's special project.
+      operationId: deleteOrgsProject
+      parameters:
+        - { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/parameters/version.yaml#/Version' }
+        - name: org_id
+          in: path
+          required: true
+          description: The id of the org containing the project
+          schema:
+            type: string
+        - name: project_id
+          in: path
+          required: true
+          description: The id of the project
+          schema:
+            type: string
+        - name: focus_type
+          in: query
+          required: true
+          description: The special project's focus
+          schema:
+            type: string
+            enum:
+              - buzzwords
+              - skunkworks
+              - bad-ideas
+              - good-ideas
+        - name: x-private-matter
+          in: header
+          description: It's a secret to everybody
+          schema:
+            type: string
+      responses:
+        '400': { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/responses/400.yaml#/400' }
+        '401': { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/responses/401.yaml#/401' }
+        '404': { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/responses/404.yaml#/404' }
+        '500': { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/responses/500.yaml#/500' }
+        '204':
+          description: 'Project was deleted'
+          headers:
+            snyk-version-requested: { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/headers/headers.yaml#/VersionRequestedResponseHeader' }
+            snyk-version-served: { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/headers/headers.yaml#/VersionServedResponseHeader' }
+            snyk-request-id: { $ref: 'https://raw.githubusercontent.com/snyk/sweater-comb/v1.2.2/components/headers/headers.yaml#/RequestIdResponseHeader' }

--- a/vervet-underground/internal/storage/revision.go
+++ b/vervet-underground/internal/storage/revision.go
@@ -85,18 +85,22 @@ func (s ServiceRevisions) ResolveLatestRevision(version vervet.Version) (Content
 }
 
 // ContentRevisions provides a deterministically ordered slice of content
-// revisions. Revisions are ordered by timestamp, newest to oldest. In the
-// unlikely event of two revisions having the same timestamp, the digest is
-// used as a tie-breaker.
+// revisions. Revisions are ordered by vervet version then timestamp, newest to
+// oldest. In the unlikely event of two revisions having the same version and
+// timestamp, the digest is used as a tie-breaker.
 type ContentRevisions []ContentRevision
 
 // Less implements sort.Interface.
 func (r ContentRevisions) Less(i, j int) bool {
-	delta := r[i].Timestamp.Sub(r[j].Timestamp)
-	if delta == 0 {
-		return r[i].Digest > r[j].Digest
+	versionDelta := r[i].Version.Date.Sub(r[j].Version.Date)
+	if versionDelta != 0 {
+		return versionDelta > 0
 	}
-	return delta > 0
+	timestampDelta := r[i].Timestamp.Sub(r[j].Timestamp)
+	if timestampDelta != 0 {
+		return timestampDelta > 0
+	}
+	return r[i].Digest > r[j].Digest
 }
 
 // Len implements sort.Interface.


### PR DESCRIPTION
If an endpoint is moved from one service to another, then there is a chance that we will continue to use the path from the old service even though the newer one has a more recent version.

It is assumed that all services are independent when doing version resolution, then all the services are merged together. This is fine if the services do not have overlapping paths but will cause unexpected behaviour otherwise.

We keep the first spec for each endpoint we find when collating versions, which means we need to find the most recent version first. To do this we can change the order we process specs by using the vervet version before the scrape timestamp - which will mean more recent versions will be processed first.