### PR TITLE
fix: log scrape errors for services

### DIFF
--- a/vervet-underground/internal/scraper/scraper.go
+++ b/vervet-underground/internal/scraper/scraper.go
@@ -125,6 +125,7 @@ func (s *Scraper) Run(ctx context.Context) error {
 			err := s.scrape(ctx, scrapeTime, svc)
 			if err != nil {
 				metrics.scrapeError.WithLabelValues(svc.base).Inc()
+				log.Error().Str("service", svc.name).Err(err).Msg("error scraping service")
 			}
 			log.Debug().Str("service", svc.name).Msg("finished scrape")
 			errCh <- err


### PR DESCRIPTION
Add an error log when an error is encountered scraping a service. Currently the errors are accumulated and logged at the end with no identifying info.