### PR TITLE
feat: skip saving legacy version when running scrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@
 
 **/server
 config.json
+config.local.json
 config.*.test.json
 result


### PR DESCRIPTION
This change will enable the use of legacy APIs using a default version `2021-01-01` (which predates `vervet`) without `vervet-underground` scraping for the OpenAPI contract. This enables `vervet` to be used on legacy APIs which do not meet the OpenAPI standard.

To test to end to end:
- Run a service locally with an API using the default version `2021-01-01`.
- Used a `config.local.json` file to point to that service.
- Started `vervet-underground` after updating the `docker-compose.yml` and `server.go` to point to the `config.local.json` file
- Called `http://localhost:8080/openapi` confirm the default version is missing from the response.