### PR TITLE
chore: update go version to 1.20 for vervet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
   resource_class: small
   working_directory: ~/vervet
   docker:
-    - image: cimg/go:1.19-node
+    - image: cimg/go:1.20-node
 
 test_vu_defaults: &test_vu_defaults
   resource_class: medium

--- a/Makefile
+++ b/Makefile
@@ -62,3 +62,7 @@ endif
 format: ## Format source code with gofmt and golangci-lint
 	gofmt -s -w .
 	golangci-lint run --fix -v ./...
+
+.PHONY: tidy
+tidy:
+	go mod tidy -v

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/vervet/v5
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.0


### PR DESCRIPTION
## What this PR does?

Keeping up with the go version, updating the Vervet go version to 1.20. Next will be updating the `vervet-underground`.

Add phony tidy target to the makefile to run `go mod tidy -v` for ease of use.