### PR TITLE
chore: consistent go and golangci-lint versions for both vervet and VU

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ vu_metadata: &vu_metadata
     resource_class: small
     working_directory: ~/vervet/vervet-underground
     docker:
-      - image: cimg/go:1.17-node
+      - image: cimg/go:1.20-node
 
 orbs:
   go: circleci/go@1.7.1
@@ -56,7 +56,7 @@ jobs:
       - run:
           name: Install Go
           command: |-
-            sudo rm -rf /usr/local/go && curl -sSL -o /tmp/go.tar.gz "https://go.dev/dl/go1.18.4.linux-amd64.tar.gz" && sudo tar -xz -f /tmp/go.tar.gz -C /usr/local
+            sudo rm -rf /usr/local/go && curl -sSL -o /tmp/go.tar.gz "https://go.dev/dl/go1.20.3.linux-amd64.tar.gz" && sudo tar -xz -f /tmp/go.tar.gz -C /usr/local
             sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
       - attach_workspace:
           at: ~/vervet
@@ -76,7 +76,7 @@ jobs:
 
   lint-vu:
     docker:
-      - image: golangci/golangci-lint:v1.43.0
+      - image: golangci/golangci-lint:v1.51.0
     steps:
       - checkout
       - attach_workspace:

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ config.*.test.json
 result
 
 .bin/
+./vervet-undergroud/.bin/

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint:
 
 .PHONY: lint-docker
 lint-docker:
-	docker run --rm -v $(shell pwd):/vervet -w /vervet golangci/golangci-lint:v1.43 golangci-lint run -v ./...
+	docker run --rm -v $(shell pwd):/vervet -w /vervet golangci/golangci-lint:${GOCI_LINT_V} golangci-lint run -v ./...
 
 #----------------------------------------------------------------------------------
 #  Ignores the test cache and forces a full test suite execution

--- a/vervet-underground/.golangci.yml
+++ b/vervet-underground/.golangci.yml
@@ -57,10 +57,10 @@ linters-settings:
   # ST1001: Dot imports that aren’t in external test packages are discouraged.
   stylecheck:
     checks: [ "all", "-ST1003" ]
-    go: "1.17"
+    go: "1.20"
   staticcheck:
     checks: ["all"]
-    go: "1.17"
+    go: "1.20"
 
 linters:
   enable:

--- a/vervet-underground/Dockerfile
+++ b/vervet-underground/Dockerfile
@@ -1,5 +1,5 @@
 # Build
-FROM golang:1.17 as builder
+FROM golang:1.20 as builder
 ADD . /src
 WORKDIR /src
 RUN go mod download

--- a/vervet-underground/Makefile
+++ b/vervet-underground/Makefile
@@ -1,3 +1,9 @@
+GO_BIN=$(shell pwd)/.bin/go
+
+SHELL:=env PATH=$(GO_BIN):$(PATH) $(SHELL)
+
+GOCI_LINT_V?=v1.51.0
+
 .PHONY: fmt
 fmt:
 	go fmt ./...
@@ -12,11 +18,11 @@ lint:
 
 .PHONY: lint-docker
 lint-docker:
-	docker run --rm -v $(shell pwd):/vervet-underground -w /vervet-underground golangci/golangci-lint:v1.43.0 golangci-lint run --fix -v ./...
+	docker run --rm -v $(shell pwd):/vervet-underground -w /vervet-underground golangci/golangci-lint:${GOCI_LINT_V} golangci-lint run --fix -v ./...
 
 .PHONY: tidy
 tidy:
-	go build tidy -v
+	go mod tidy -v
 
 .PHONY: test
 test:
@@ -45,3 +51,15 @@ test-coverage:
 .PHONY: start
 start:
 	go run server.go
+
+.PHONY: install-tools
+install-tools: 
+ifndef CI
+	mkdir -p ${GO_BIN}
+	curl -sSfL 'https://raw.githubusercontent.com/golangci/golangci-lint/${GOCI_LINT_V}/install.sh' | sh -s -- -b ${GO_BIN} ${GOCI_LINT_V}
+endif
+
+.PHONY: format
+format: ## Format source code with gofmt and golangci-lint
+	gofmt -s -w .
+	golangci-lint run --fix -v ./...

--- a/vervet-underground/go.mod
+++ b/vervet-underground/go.mod
@@ -1,6 +1,6 @@
 module vervet-underground
 
-go 1.17
+go 1.20
 
 require (
 	cloud.google.com/go/storage v1.22.0

--- a/vervet-underground/internal/storage/gcs/testing/testing.go
+++ b/vervet-underground/internal/storage/gcs/testing/testing.go
@@ -122,5 +122,5 @@ func findOpenPort(c *qt.C) string {
 	ln, err := net.Listen("tcp", "localhost:0")
 	c.Assert(err, qt.IsNil)
 	defer ln.Close()
-	return strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+	return strconv.Itoa(ln.Addr().(*net.TCPAddr).Port) //nolint:forcetypeassert // acked
 }


### PR DESCRIPTION
- Update the vervet underground go and `golangci-lint` versions to match that of `vervet` to ensure a consistent experience.
- Update the `vervet undergound` `makefile` to install `golangci-lint` in the local bin, enabling us to work on `vervet underground` independently. It also replicates the setup of `vervet`.
- Update docker and ci config files to use the correct version of go and `golangci-lint`.