### PR TITLE
fix: update image publishing project tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,9 +204,7 @@ workflows:
           fedramp: "no"
           snyk_organization: platform-extensibility
           snyk_token_variable: MONITOR_SNYK_TOKEN
-          snyk_project_tags: >-
-            component=pkg:github/snyk/vervet-underground@main,
-            component=pkg:github/snyk/vervet@main
+          snyk_project_tags: component=pkg:github/snyk/vervet-underground@main,component=pkg:github/snyk/vervet@main
           context:
             - snyk-docker-build
             - infra-publish-orb


### PR DESCRIPTION
This PR introduces a small fix to remove a space from between the project tags.
This should unblock the publish step:
https://app.circleci.com/pipelines/github/snyk/vervet/1361/workflows/dc359287-8cda-48c1-b530-4e30bd823115/jobs/4216