### PR TITLE
fix: provide a Versions method on VersionIndex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/urfave/cli/v2 v2.25.7
 	github.com/vmware-labs/yaml-jsonpath v0.3.2
 	go.uber.org/multierr v1.11.0
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2Uz
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=

--- a/resource.go
+++ b/resource.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"sort"
 	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/getkin/kin-openapi/openapi3"
+	"golang.org/x/exp/maps"
 )
 
 const (
@@ -125,14 +125,7 @@ func (rv *ResourceVersions) Name() string {
 
 // Versions returns each Version defined for this resource.
 func (rv *ResourceVersions) Versions() VersionSlice {
-	result := make(VersionSlice, len(rv.versions))
-	i := 0
-	for v := range rv.versions {
-		result[i] = v
-		i++
-	}
-	sort.Sort(result)
-	return result
+	return rv.index.Versions()
 }
 
 // ErrNoMatchingVersion indicates the requested version cannot be satisfied by
@@ -275,7 +268,7 @@ func LoadResourceVersionsFileset(specYamls []string) (*ResourceVersions, error) 
 			}
 		}
 	}
-	resourceVersions.index = NewVersionIndex((resourceVersions.Versions()))
+	resourceVersions.index = NewVersionIndex(maps.Keys(resourceVersions.versions))
 	return &resourceVersions, nil
 }
 

--- a/versionware/example/go.mod
+++ b/versionware/example/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/versionware/example/go.sum
+++ b/versionware/example/go.sum
@@ -72,6 +72,8 @@ github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4d
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Provides a Versions method on the VersionIndex type which returns a copy of the VersionSlice used to build the index.

This is a pre-requisite to upgrade the vervet version of vervet-underground.