### PR TITLE
fix: update nix flake after dependency upgrade

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@ buildGoModule rec {
   version = builtins.substring 0 8 lastMod;
   src = ./.;
 
-  vendorSha256 = "sha256-uDM4svFIGn3kS0ygA6aDCDI8OVCrxzHmLkc+6XWdKB4=";
+  vendorSha256 = "sha256-QowTqiXNJ8G2X/UXhDnOVqL7AZdLcAhHwung5D8+4pI=";
 
   meta = with lib; {
     description = "API resource versioning tool";

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678298120,
-        "narHash": "sha256-iaV5xqgn29xy765Js3EoZePQyZIlLZA3pTYtTnKkejg=",
+        "lastModified": 1699186365,
+        "narHash": "sha256-Pxrw5U8mBsL3NlrJ6q1KK1crzvSUcdfwb9083sKDrcU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1e383aada51b416c6c27d4884d2e258df201bc11",
+        "rev": "a0b3b06b7a82c965ae0bb1d59f6e386fe755001d",
         "type": "github"
       },
       "original": {
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
             stdenv lib python2 runCommand writeTextFile writeShellScript;
           inherit pkgs;
           libtool = pkgs.darwin.cctools;
-          nodejs = pkgs.nodejs-14_x;
+          nodejs = pkgs.nodejs;
         };
       in rec {
         packages = flake-utils.lib.flattenTree {

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ let
     buildNodePackage = nodeEnv.buildNodePackage;
   };
 in pkgs.mkShell {
-  nativeBuildInputs = with pkgs.buildPackages; [ go_1_19 envsubst spectral ];
+  nativeBuildInputs = with pkgs.buildPackages; [ go_1_21 envsubst spectral ];
   shellHook = ''
     export GOPATH="$HOME/.cache/gopaths/$(sha256sum <<<$(pwd) | awk '{print $1}')"
   '';


### PR DESCRIPTION
Main change is updating the dependencies hash so it is up to date with the most recent changes.

Additionally the devshell has been updated to use the latest node LTS and match the go version defined in go.mod, which required an update to nixpkgs.