### PR TITLE
feat: update auxiliary modules to use vervet v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ In this case, a template is being applied per `operationId` in the `spec.yaml` g
 
 Finally, a note on scoping. Generators can be scoped to either a `version` or a `resource`.
 
-`scope: version` generator templates execute with [VersionScope](https://pkg.go.dev/github.com/snyk/vervet/v5/internal/generator#VersionScope). This maps 1:1 with a single resource version OpenAPI specification.
+`scope: version` generator templates execute with [VersionScope](https://pkg.go.dev/github.com/snyk/vervet/v6/internal/generator#VersionScope). This maps 1:1 with a single resource version OpenAPI specification.
 
-`scope: resource` generator templates execute with [ResourceScope](https://pkg.go.dev/github.com/snyk/vervet/v5/internal/generator#ResourceScope). This is a collection of resource versions, useful for building resource routers.
+`scope: resource` generator templates execute with [ResourceScope](https://pkg.go.dev/github.com/snyk/vervet/v6/internal/generator#ResourceScope). This is a collection of resource versions, useful for building resource routers.
 
 ## Installation
 
@@ -211,7 +211,7 @@ NPM packaging adapted from https://github.com/manifoldco/torus-cli.
 
 Go >= 1.16 required.
 
-    go install github.com/snyk/vervet/v5/cmd/vervet@latest
+    go install github.com/snyk/vervet/v6/cmd/vervet@latest
 
 Building from source locally:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 nav:
 - Go packages:
-  - github.com/snyk/vervet/v5: github.com/snyk/vervet/v5.md
-  - github.com/snyk/vervet/v5/config: github.com/snyk/vervet/v5/config.md
-  - github.com/snyk/vervet/v5/versionware: github.com/snyk/vervet/v5/versionware.md
+  - github.com/snyk/vervet/v6: github.com/snyk/vervet/v6.md
+  - github.com/snyk/vervet/v6/config: github.com/snyk/vervet/v6/config.md
+  - github.com/snyk/vervet/v6/versionware: github.com/snyk/vervet/v6/versionware.md
 plugins:
 - techdocs-core
 site_name: vervet

--- a/versionware/example/chi/example_test.go
+++ b/versionware/example/chi/example_test.go
@@ -15,14 +15,14 @@ import (
 	promware "github.com/slok/go-http-metrics/middleware"
 	promware_std "github.com/slok/go-http-metrics/middleware/std"
 
-	"github.com/snyk/vervet/v5"
-	"github.com/snyk/vervet/v5/versionware"
-	. "github.com/snyk/vervet/v5/versionware/example"
-	"github.com/snyk/vervet/v5/versionware/example/releases"
-	release_2021_11_01 "github.com/snyk/vervet/v5/versionware/example/resources/things/2021-11-01"
-	release_2021_11_08 "github.com/snyk/vervet/v5/versionware/example/resources/things/2021-11-08"
-	release_2021_11_20 "github.com/snyk/vervet/v5/versionware/example/resources/things/2021-11-20"
-	"github.com/snyk/vervet/v5/versionware/example/store"
+	"github.com/snyk/vervet/v6"
+	"github.com/snyk/vervet/v6/versionware"
+	. "github.com/snyk/vervet/v6/versionware/example"
+	"github.com/snyk/vervet/v6/versionware/example/releases"
+	release_2021_11_01 "github.com/snyk/vervet/v6/versionware/example/resources/things/2021-11-01"
+	release_2021_11_08 "github.com/snyk/vervet/v6/versionware/example/resources/things/2021-11-08"
+	release_2021_11_20 "github.com/snyk/vervet/v6/versionware/example/resources/things/2021-11-20"
+	"github.com/snyk/vervet/v6/versionware/example/store"
 )
 
 func Example() {

--- a/versionware/example/embed_test.go
+++ b/versionware/example/embed_test.go
@@ -5,8 +5,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/snyk/vervet/v5"
-	"github.com/snyk/vervet/v5/versionware/example/releases"
+	"github.com/snyk/vervet/v6"
+	"github.com/snyk/vervet/v6/versionware/example/releases"
 )
 
 func TestEmbedding(t *testing.T) {

--- a/versionware/example/go.mod
+++ b/versionware/example/go.mod
@@ -1,4 +1,4 @@
-module github.com/snyk/vervet/v5/versionware/example
+module github.com/snyk/vervet/v6/versionware/example
 
 go 1.21
 
@@ -9,7 +9,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/slok/go-http-metrics v0.11.0
-	github.com/snyk/vervet/v5 v5.7.0
+	github.com/snyk/vervet/v6 v6.0.0
 )
 
 require (
@@ -35,7 +35,8 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+	golang.org/x/sys v0.15.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/versionware/example/go.sum
+++ b/versionware/example/go.sum
@@ -64,8 +64,8 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/slok/go-http-metrics v0.11.0 h1:ABJUpekCZSkQT1wQrFvS4kGbhea/w6ndFJaWJeh3zL0=
 github.com/slok/go-http-metrics v0.11.0/go.mod h1:ZGKeYG1ET6TEJpQx18BqAJAvxw9jBAZXCHU7bWQqqAc=
-github.com/snyk/vervet/v5 v5.7.0 h1:skvFZiEMke/qoCFQzjU5vP1TuWoiBrEuQC9cioqHNXA=
-github.com/snyk/vervet/v5 v5.7.0/go.mod h1:Ln3gyEmOlrifVH7HCwGOkzW2w+2ESW0NtdbCUv1XSPI=
+github.com/snyk/vervet/v6 v6.0.0 h1:acmoY49D7HXcrpW58Izh3CMlAodg+YurUqDY5H5m/sg=
+github.com/snyk/vervet/v6 v6.0.0/go.mod h1:+yEWhrnAr/mlsRexWfzOaFlmVPODKmhxMuRofrRsWzI=
 github.com/stretchr/objx v0.5.1 h1:4VhoImhV/Bm0ToFkXFi8hXNXwpDRZ/ynw3amt82mzq0=
 github.com/stretchr/objx v0.5.1/go.mod h1:/iHQpkQwBD6DLUmQ4pE+s1TXdob1mORJ4/UFdrifcy0=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
@@ -74,8 +74,10 @@ github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4d
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=

--- a/versionware/example/gorilla/example_test.go
+++ b/versionware/example/gorilla/example_test.go
@@ -13,14 +13,14 @@ import (
 	promware "github.com/slok/go-http-metrics/middleware"
 	promware_std "github.com/slok/go-http-metrics/middleware/std"
 
-	"github.com/snyk/vervet/v5"
-	"github.com/snyk/vervet/v5/versionware"
-	. "github.com/snyk/vervet/v5/versionware/example"
-	"github.com/snyk/vervet/v5/versionware/example/releases"
-	release_2021_11_01 "github.com/snyk/vervet/v5/versionware/example/resources/things/2021-11-01"
-	release_2021_11_08 "github.com/snyk/vervet/v5/versionware/example/resources/things/2021-11-08"
-	release_2021_11_20 "github.com/snyk/vervet/v5/versionware/example/resources/things/2021-11-20"
-	"github.com/snyk/vervet/v5/versionware/example/store"
+	"github.com/snyk/vervet/v6"
+	"github.com/snyk/vervet/v6/versionware"
+	. "github.com/snyk/vervet/v6/versionware/example"
+	"github.com/snyk/vervet/v6/versionware/example/releases"
+	release_2021_11_01 "github.com/snyk/vervet/v6/versionware/example/resources/things/2021-11-01"
+	release_2021_11_08 "github.com/snyk/vervet/v6/versionware/example/resources/things/2021-11-08"
+	release_2021_11_20 "github.com/snyk/vervet/v6/versionware/example/resources/things/2021-11-20"
+	"github.com/snyk/vervet/v6/versionware/example/store"
 )
 
 func Example() {

--- a/versionware/example/resources/things/2021-11-01/handlers.go
+++ b/versionware/example/resources/things/2021-11-01/handlers.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/snyk/vervet/v5"
-	"github.com/snyk/vervet/v5/versionware/example/resources/things"
-	"github.com/snyk/vervet/v5/versionware/example/store"
+	"github.com/snyk/vervet/v6"
+	"github.com/snyk/vervet/v6/versionware/example/resources/things"
+	"github.com/snyk/vervet/v6/versionware/example/store"
 )
 
 // Version is the resource release version of handlers in this package.

--- a/versionware/example/resources/things/2021-11-08/handlers.go
+++ b/versionware/example/resources/things/2021-11-08/handlers.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/snyk/vervet/v5"
-	"github.com/snyk/vervet/v5/versionware/example/resources/things"
-	"github.com/snyk/vervet/v5/versionware/example/store"
+	"github.com/snyk/vervet/v6"
+	"github.com/snyk/vervet/v6/versionware/example/resources/things"
+	"github.com/snyk/vervet/v6/versionware/example/store"
 )
 
 // Version is the resource release version of handlers in this package.

--- a/versionware/example/resources/things/2021-11-20/handlers.go
+++ b/versionware/example/resources/things/2021-11-20/handlers.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/snyk/vervet/v5"
-	"github.com/snyk/vervet/v5/versionware/example/store"
+	"github.com/snyk/vervet/v6"
+	"github.com/snyk/vervet/v6/versionware/example/store"
 )
 
 // Version is the resource release version of handlers in this package.

--- a/versionware/example/resources/things/types.go
+++ b/versionware/example/resources/things/types.go
@@ -4,7 +4,7 @@ package things
 import (
 	"time"
 
-	"github.com/snyk/vervet/v5/versionware/example/store"
+	"github.com/snyk/vervet/v6/versionware/example/store"
 )
 
 // Attributes represents the data contents of a Thing resource.

--- a/vervet-underground/config/config.go
+++ b/vervet-underground/config/config.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/snyk/vervet/v5"
+	"github.com/snyk/vervet/v6"
 	"github.com/spf13/viper"
 )
 

--- a/vervet-underground/config/config_test.go
+++ b/vervet-underground/config/config_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/snyk/vervet/v5"
+	"github.com/snyk/vervet/v6"
 
 	"vervet-underground/config"
 )

--- a/vervet-underground/go.mod
+++ b/vervet-underground/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/prometheus/client_model v0.5.0
 	github.com/rs/zerolog v1.31.0
 	github.com/slok/go-http-metrics v0.11.0
-	github.com/snyk/vervet/v5 v5.10.1
+	github.com/snyk/vervet/v6 v6.0.0
 	github.com/spf13/viper v1.17.0
 	github.com/testcontainers/testcontainers-go v0.26.0
 	go.uber.org/multierr v1.11.0

--- a/vervet-underground/go.sum
+++ b/vervet-underground/go.sum
@@ -369,8 +369,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/slok/go-http-metrics v0.11.0 h1:ABJUpekCZSkQT1wQrFvS4kGbhea/w6ndFJaWJeh3zL0=
 github.com/slok/go-http-metrics v0.11.0/go.mod h1:ZGKeYG1ET6TEJpQx18BqAJAvxw9jBAZXCHU7bWQqqAc=
-github.com/snyk/vervet/v5 v5.10.1 h1:ImEr5E44BCpSvBSu7wuW7deA/3Yg2w5afXnkzHNL84I=
-github.com/snyk/vervet/v5 v5.10.1/go.mod h1:kZdxIksZidEl/2CEf8fiDcOsDvPVD4BD6KgaqNezqbw=
+github.com/snyk/vervet/v6 v6.0.0 h1:acmoY49D7HXcrpW58Izh3CMlAodg+YurUqDY5H5m/sg=
+github.com/snyk/vervet/v6 v6.0.0/go.mod h1:+yEWhrnAr/mlsRexWfzOaFlmVPODKmhxMuRofrRsWzI=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.10.0 h1:EaGW2JJh15aKOejeuJ+wpFSHnbd7GE6Wvp3TsNhb6LY=

--- a/vervet-underground/internal/handler/handler.go
+++ b/vervet-underground/internal/handler/handler.go
@@ -15,8 +15,8 @@ import (
 	metrics "github.com/slok/go-http-metrics/metrics/prometheus"
 	prommiddleware "github.com/slok/go-http-metrics/middleware"
 	prommiddlewarestd "github.com/slok/go-http-metrics/middleware/std"
-	"github.com/snyk/vervet/v5"
-	"github.com/snyk/vervet/v5/versionware"
+	"github.com/snyk/vervet/v6"
+	"github.com/snyk/vervet/v6/versionware"
 
 	"vervet-underground/config"
 	"vervet-underground/internal/scraper"

--- a/vervet-underground/internal/handler/handler_test.go
+++ b/vervet-underground/internal/handler/handler_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/snyk/vervet/v5"
+	"github.com/snyk/vervet/v6"
 
 	"vervet-underground/config"
 	"vervet-underground/internal/handler"

--- a/vervet-underground/internal/scraper/scraper.go
+++ b/vervet-underground/internal/scraper/scraper.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
-	"github.com/snyk/vervet/v5"
+	"github.com/snyk/vervet/v6"
 	"go.uber.org/multierr"
 
 	"vervet-underground/config"

--- a/vervet-underground/internal/storage/collator.go
+++ b/vervet-underground/internal/storage/collator.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/rs/zerolog/log"
-	"github.com/snyk/vervet/v5"
+	"github.com/snyk/vervet/v6"
 )
 
 // Collator is an aggregate of service specs and uniqueVersions scraped by VU. It is responsible for collating uniqueVersions and

--- a/vervet-underground/internal/storage/collator_test.go
+++ b/vervet-underground/internal/storage/collator_test.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/snyk/vervet/v5"
-	"github.com/snyk/vervet/v5/testdata"
+	"github.com/snyk/vervet/v6"
+	"github.com/snyk/vervet/v6/testdata"
 
 	"vervet-underground/internal/storage"
 )

--- a/vervet-underground/internal/storage/gcs/client.go
+++ b/vervet-underground/internal/storage/gcs/client.go
@@ -13,7 +13,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/rs/zerolog/log"
-	"github.com/snyk/vervet/v5"
+	"github.com/snyk/vervet/v6"
 	"go.uber.org/multierr"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"

--- a/vervet-underground/internal/storage/mem/mem.go
+++ b/vervet-underground/internal/storage/mem/mem.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
-	"github.com/snyk/vervet/v5"
+	"github.com/snyk/vervet/v6"
 
 	"vervet-underground/internal/storage"
 )

--- a/vervet-underground/internal/storage/revision.go
+++ b/vervet-underground/internal/storage/revision.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/snyk/vervet/v5"
+	"github.com/snyk/vervet/v6"
 )
 
 // ContentRevision is the exact contents and metadata of a service's version at scraping timestamp.

--- a/vervet-underground/internal/storage/revision_test.go
+++ b/vervet-underground/internal/storage/revision_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/snyk/vervet/v5"
+	"github.com/snyk/vervet/v6"
 
 	"vervet-underground/internal/storage"
 )

--- a/vervet-underground/internal/storage/s3/client.go
+++ b/vervet-underground/internal/storage/s3/client.go
@@ -21,7 +21,7 @@ import (
 	"github.com/aws/smithy-go"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/rs/zerolog/log"
-	"github.com/snyk/vervet/v5"
+	"github.com/snyk/vervet/v6"
 	"go.uber.org/multierr"
 
 	"vervet-underground/internal/storage"

--- a/vervet-underground/internal/storage/storage.go
+++ b/vervet-underground/internal/storage/storage.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/rs/zerolog/log"
-	"github.com/snyk/vervet/v5"
+	"github.com/snyk/vervet/v6"
 )
 
 // Storage defines the storage functionality needed in order to store service


### PR DESCRIPTION
There are multiple modules in this repo that depend on each other by external package names. As such we could not update them all at once until the main package was released. That has now happened so we can update all the other references.