### PR TITLE
fix: resolve highest stability from versionware

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -3,7 +3,3 @@ package vervet
 // TimeNow is a patchable func pointer to obtain time.Now in the
 // version.go file, used for mocking time in tests.
 var TimeNow = &timeNow
-
-func (vi *VersionIndex) ResolveForBuild(v Version) (Version, error) {
-	return vi.resolveForBuild(v)
-}

--- a/resource.go
+++ b/resource.go
@@ -144,7 +144,7 @@ func (rv *ResourceVersions) At(vs string) (*ResourceVersion, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid version %q: %w", vs, err)
 	}
-	resolvedVersion, err := rv.index.resolveForBuild(v)
+	resolvedVersion, err := rv.index.ResolveForBuild(v)
 	if err != nil {
 		return nil, err
 	}

--- a/version.go
+++ b/version.go
@@ -336,13 +336,13 @@ func (vi *VersionIndex) resolveIndex(query time.Time) (int, error) {
 	return lower, nil
 }
 
-// resolveForBuild returns the most stable version effective on the query
+// ResolveForBuild returns the most stable version effective on the query
 // version date with respect to the given version stability. Returns
 // ErrNoMatchingVersion if no version matches.
 //
-// Use resolveForBuild when resolving version deprecation and effective releases
+// Use ResolveForBuild when resolving version deprecation and effective releases
 // _within a single resource_ during the "compilation" or "collation" process.
-func (vi *VersionIndex) resolveForBuild(query Version) (Version, error) {
+func (vi *VersionIndex) ResolveForBuild(query Version) (Version, error) {
 	i, err := vi.resolveIndex(query.Date)
 	if err != nil {
 		return Version{}, err

--- a/versionware/handler.go
+++ b/versionware/handler.go
@@ -69,7 +69,7 @@ func (h *Handler) HandleErrors(errFunc VersionErrorHandler) {
 // Resolve returns the resolved version and its associated http.Handler for the
 // requested version.
 func (h *Handler) Resolve(requested vervet.Version) (*vervet.Version, http.Handler, error) {
-	resolvedVersion, err := h.index.Resolve(requested)
+	resolvedVersion, err := h.index.ResolveForBuild(requested)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/versionware/handler_test.go
+++ b/versionware/handler_test.go
@@ -57,6 +57,12 @@ func ExampleHandler() {
 func TestHandler(t *testing.T) {
 	c := qt.New(t)
 	h := versionware.NewHandler([]versionware.VersionHandler{{
+		Version: vervet.MustParseVersion("2021-08-01~beta"),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := w.Write([]byte("aug beta"))
+			c.Assert(err, qt.IsNil)
+		}),
+	}, {
 		Version: vervet.MustParseVersion("2021-10-01"),
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, err := w.Write([]byte("oct"))
@@ -95,6 +101,12 @@ func TestHandler(t *testing.T) {
 		"2021-11-05", "2021-11-01", "nov", 200,
 	}, {
 		"2023-02-05", "2021-11-01", "nov", 200,
+	}, {
+		"2021-08-01", "", "Not Found\n", 404,
+	}, {
+		"2021-08-01~beta", "2021-08-01~beta", "aug beta", 200,
+	}, {
+		"2021-09-01~beta", "2021-09-01", "sept", 200,
 	}}
 	for i, test := range tests {
 		c.Run(fmt.Sprintf("%d requested %s resolved %s", i, test.requested, test.resolved), func(c *qt.C) {


### PR DESCRIPTION
When compiling specs we always show the highest stability level for a given version of an endpoint. As such we need to use the same logic when resolving handlers for dealing with that endpoint.

Before this patch it is possible that a request for a beta version will hit the handler for the beta endpoint, but then the request would be validated for the GA version of the same endpoint causing the request to fail.

This aligns endpoint behaviour with what we publicly document for a specific version.