### PR TITLE
fix: use correct docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ commands:
   setup_build_remote_docker:
     steps:
       - setup_remote_docker:
+          version: default      
           docker_layer_caching: false
 
 jobs:


### PR DESCRIPTION
We're in a brownout, might as well do the upgrade to the "default" docker image in circle ci for build