### PR TITLE
fix: update Snyk Node base images

### DIFF
--- a/vervet-underground/Dockerfile
+++ b/vervet-underground/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # we're not changing anything, only making it explicit.
 # Thanks to emulation, this will also run on ARM Macs.
 # Advised to move from distroless to the secure base image - https://docs.google.com/document/d/1I-vxsuHlmBlM8JHSDpvOmVMGeQQcbPgb8jH1ELEE9wo/edit#heading=h.1xke9mez8zov
-FROM --platform=amd64 gcr.io/snyk-main/ubuntu-20:2.1.0_202308221557
+FROM --platform=amd64 gcr.io/snyk-main/ubuntu-20:2.3.1_202403150706
 
 COPY config.*.json /
 COPY --from=builder /go/bin/app /


### PR DESCRIPTION
Use Snyk Node base images version [2.3.1_202403150706](https://github.com/snyk/snyk-base-images/releases/tag/2.3.1_202403150706) to pickup security fixes. See [PRODSEC-1765](https://snyksec.atlassian.net/browse/PRODSEC-1765) for details.

-- 
Snyk ProdSec

[PRODSEC-1765]: https://snyksec.atlassian.net/browse/PRODSEC-1765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ