### PR TITLE
fix: throw error when conflicting components are found

### DIFF
--- a/collator.go
+++ b/collator.go
@@ -244,7 +244,7 @@ var cmpComponents = cmp.Options{
 	// Refs themselves can mutate during relocation, so they are excluded from
 	// content comparison.
 	cmp.FilterPath(func(p cmp.Path) bool {
-		return p.Last().String() == ".Ref"
+		return p.Last().String() == ".Ref" || p.Last().String() == ".extra"
 	}, cmp.Ignore()),
 }
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -184,10 +184,16 @@ func (c *Compiler) Build(ctx context.Context, apiName string) error {
 
 			// Merge all overlays
 			for _, doc := range api.overlayIncludes {
-				vervet.Merge(spec, doc.T, true)
+				err = vervet.Merge(spec, doc.T, true)
+				if err != nil {
+					return buildErr(err)
+				}
 			}
 			for _, doc := range api.overlayInlines {
-				vervet.Merge(spec, doc, true)
+				err = vervet.Merge(spec, doc, true)
+				if err != nil {
+					return buildErr(err)
+				}
 			}
 
 			// Write the compiled spec to JSON and YAML

--- a/merge_test.go
+++ b/merge_test.go
@@ -24,11 +24,18 @@ var openapiCmp = qt.CmpEquals(cmpopts.IgnoreUnexported(
 
 func TestMergeComponents(t *testing.T) {
 	c := qt.New(t)
+	c.Run("component without replace and conflict", func(c *qt.C) {
+		src := mustLoadFile(c, "merge_test_conflict.yaml")
+		dst := mustLoadFile(c, "merge_test_dst.yaml")
+		err := vervet.Merge(dst, src, false)
+		c.Assert(err, qt.IsNotNil)
+	})
 	c.Run("component without replace", func(c *qt.C) {
 		src := mustLoadFile(c, "merge_test_src.yaml")
 		dstOrig := mustLoadFile(c, "merge_test_dst.yaml")
 		dst := mustLoadFile(c, "merge_test_dst.yaml")
-		vervet.Merge(dst, src, false)
+		err := vervet.Merge(dst, src, false)
+		c.Assert(err, qt.IsNil)
 
 		c.Assert(dst.Components.Schemas["Foo"], openapiCmp, dstOrig.Components.Schemas["Foo"])
 		c.Assert(dst.Components.Schemas["Bar"], openapiCmp, src.Components.Schemas["Bar"])
@@ -62,7 +69,8 @@ func TestMergeComponents(t *testing.T) {
 		src := mustLoadFile(c, "merge_test_src.yaml")
 		dstOrig := mustLoadFile(c, "merge_test_dst.yaml")
 		dst := mustLoadFile(c, "merge_test_dst.yaml")
-		vervet.Merge(dst, src, true)
+		err := vervet.Merge(dst, src, true)
+		c.Assert(err, qt.IsNil)
 
 		c.Assert(dst.Components.Schemas["Foo"], openapiCmp, src.Components.Schemas["Foo"])
 		c.Assert(dst.Components.Schemas["Bar"], openapiCmp, src.Components.Schemas["Bar"])
@@ -96,7 +104,8 @@ func TestMergeComponents(t *testing.T) {
 		src := mustLoadFile(c, "merge_test_src.yaml")
 		dstOrig := mustLoadFile(c, "merge_test_dst_missing_components.yaml")
 		dst := mustLoadFile(c, "merge_test_dst_missing_components.yaml")
-		vervet.Merge(dst, src, true)
+		err := vervet.Merge(dst, src, true)
+		c.Assert(err, qt.IsNil)
 
 		c.Assert(dst.Components.Schemas["Foo"], openapiCmp, src.Components.Schemas["Foo"])
 		c.Assert(dst.Components.Schemas["Bar"], openapiCmp, src.Components.Schemas["Bar"])
@@ -147,7 +156,8 @@ tags:
 	c.Run("tags without replace", func(c *qt.C) {
 		src := mustLoad(c, srcYaml)
 		dst := mustLoad(c, dstYaml)
-		vervet.Merge(dst, src, false)
+		err := vervet.Merge(dst, src, false)
+		c.Assert(err, qt.IsNil)
 		c.Assert(dst.Tags, qt.DeepEquals, openapi3.Tags{{
 			Extensions:  map[string]interface{}{},
 			Name:        "bar",
@@ -165,7 +175,8 @@ tags:
 	c.Run("tags with replace", func(c *qt.C) {
 		src := mustLoad(c, srcYaml)
 		dst := mustLoad(c, dstYaml)
-		vervet.Merge(dst, src, true)
+		err := vervet.Merge(dst, src, true)
+		c.Assert(err, qt.IsNil)
 		c.Assert(dst.Tags, qt.DeepEquals, openapi3.Tags{{
 			Extensions:  map[string]interface{}{},
 			Name:        "bar",
@@ -225,7 +236,8 @@ x-extension:
 	c.Run("without replace", func(c *qt.C) {
 		src := mustLoad(c, srcYaml)
 		dst := mustLoad(c, dstYaml)
-		vervet.Merge(dst, src, false)
+		err := vervet.Merge(dst, src, false)
+		c.Assert(err, qt.IsNil)
 		c.Assert(dst.Info, qt.DeepEquals, &openapi3.Info{
 			Extensions: map[string]interface{}{},
 			Title:      "Dst",
@@ -255,7 +267,8 @@ x-extension:
 	c.Run("with replace", func(c *qt.C) {
 		src := mustLoad(c, srcYaml)
 		dst := mustLoad(c, dstYaml)
-		vervet.Merge(dst, src, true)
+		err := vervet.Merge(dst, src, true)
+		c.Assert(err, qt.IsNil)
 		c.Assert(dst.Info, qt.DeepEquals, &openapi3.Info{
 			Extensions: map[string]interface{}{},
 			Title:      "Src",
@@ -303,7 +316,8 @@ paths:
 `
 	src := mustLoad(c, srcYaml)
 	dst := &openapi3.T{}
-	vervet.Merge(dst, src, false)
+	err := vervet.Merge(dst, src, false)
+	c.Assert(err, qt.IsNil)
 	c.Assert(dst.Paths, qt.HasLen, 1)
 }
 

--- a/testdata/merge_test_conflict.yaml
+++ b/testdata/merge_test_conflict.yaml
@@ -5,13 +5,12 @@ components:
       properties:
         color:
           type: string
-          enum: ["red", "green", "blue", "alpha"]
-        quantity:
-          type: number
-    Baz:
-      type: object
-      properties:
-        other:
+          enum: ["red", "green", "blue"]
+        dimension:
+          type: array
+          items:
+            type: number
+        strange:
           type: boolean
   parameters:
     Foo:
@@ -20,17 +19,8 @@ components:
       required: true
       schema:
         type: string
-    Baz:
-      in: path
-      name: baz
-      required: true
-      schema:
-        type: string
   headers:
     Foo:
-      schema:
-        type: string
-    Baz:
       schema:
         type: string
   requestBodies:
@@ -40,32 +30,16 @@ components:
        application/json:
         schema:
           $ref: '#/components/schemas/Foo'
-    Baz:
-     required: true
-     content:
-       application/json:
-        schema:
-          $ref: '#/components/schemas/Baz'
   responses:
     '200':
       content:
         application/vnd.api+json:
           schema:
             $ref: '#/components/schemas/Foo'
-    '202':
-      content:
-        application/vnd.api+json:
-          schema:
-            $ref: '#/components/schemas/Baz'
   securitySchemes:
     Foo:
-     type: http
-     scheme: basic
-    Baz:
      type: http
      scheme: basic
   examples:
     Foo:
      value: foo
-    Baz:
-     value: bazil


### PR DESCRIPTION
When we roll up versions and copy over paths from older spec, we naïvely merge the components defined in those specs. This is a problem when similar named components are defined in two versions of a spec that is rolled up.

To fix this problem is a lot of effort which we do not have time for right now, but detecting it is relatively easy. This patch will fail building specs if we detect such a case so a user can work around it manually.