### PR TITLE
fix: update Snyk base images [PRODSEC-1788]

### DIFF
--- a/vervet-underground/Dockerfile
+++ b/vervet-underground/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # we're not changing anything, only making it explicit.
 # Thanks to emulation, this will also run on ARM Macs.
 # Advised to move from distroless to the secure base image - https://docs.google.com/document/d/1I-vxsuHlmBlM8JHSDpvOmVMGeQQcbPgb8jH1ELEE9wo/edit#heading=h.1xke9mez8zov
-FROM --platform=amd64 gcr.io/snyk-main/ubuntu-20:2.3.1_202403150706
+FROM --platform=amd64 gcr.io/snyk-main/ubuntu-20:2.3.7_202404190856
 
 COPY config.*.json /
 COPY --from=builder /go/bin/app /


### PR DESCRIPTION
Updates the snyk base image to the latest released version for security updates. See [PRODSEC-1788](https://snyksec.atlassian.net/browse/PRODSEC-1788) for details.

# **snyk-base-images** release [2.3.7_202404190856](https://github.com/snyk/snyk-base-images/releases/tag/2.3.7_202404190856)

Released on Friday April 19, 2024 at 08:58 (UTC)

## What's Changed
- **ubuntu-20-node-18**: Upgrade Node-18 base image to NodeJS version [18.20.2](https://nodejs.org/en/blog/release/v18.20.2)
- **ubuntu-20-node-20**: Upgrade Node-20 base image to NodeJS version [20.12.2](https://nodejs.org/en/blog/release/v20.12.2)

**Full Changelog**: https://github.com/snyk/snyk-base-images/compare/2.3.6_202404171800...2.3.7_202404190856

-- 
Snyk ProdSec

[PRODSEC-1788]: https://snyksec.atlassian.net/browse/PRODSEC-1788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ