### PR TITLE
fix: add scraper to VU container image

### DIFF
--- a/vervet-underground/Dockerfile
+++ b/vervet-underground/Dockerfile
@@ -35,6 +35,7 @@ FROM --platform=amd64 gcr.io/snyk-main/ubuntu-20:2.3.7_202404190856
 
 COPY config.*.json /
 COPY --from=builder /go/bin/app /
+COPY --from=builder /go/bin/scraper /
 
 USER snyk
 


### PR DESCRIPTION
We run the same container image for the api and scraper, so we actually need the scraper binary in that image. Previous patch built it in the build stage but forgot to copy it to the final image.