### PR TITLE
fix: report better error when building future versions

### DIFF
--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/ghodss/yaml"
@@ -165,6 +166,13 @@ func (c *Compiler) Build(ctx context.Context, apiName string) error {
 		}
 		versions := specVersions.Versions()
 		for _, version := range versions {
+			if version.LifecycleAt(time.Now()) == vervet.LifecycleUnreleased {
+				return buildErr(fmt.Errorf(
+					"API spec with version %s is in the future. This is not supported as it may cause breakage",
+					version,
+				))
+			}
+
 			spec, err := specVersions.At(version)
 			if err == vervet.ErrNoMatchingVersion {
 				continue

--- a/version.go
+++ b/version.go
@@ -442,6 +442,8 @@ func (l Lifecycle) String() string {
 		return "deprecated"
 	case LifecycleSunset:
 		return "sunset"
+	case LifecycleUnreleased:
+		return "unreleased"
 	default:
 		panic(fmt.Sprintf("invalid lifecycle (%d)", int(l)))
 	}

--- a/version_test.go
+++ b/version_test.go
@@ -437,13 +437,3 @@ func TestLifecycleAtDefaultDate(t *testing.T) {
 		})
 	}
 }
-
-func TestLifecycleAtUnreleasedVersionStringPanics(t *testing.T) {
-	c := qt.New(t)
-	c.Patch(TimeNow, func() time.Time { return time.Date(2022, time.June, 6, 14, 49, 50, 0, time.UTC) })
-	version := MustParseVersion("2022-10-16~wip")
-	lifecycle := version.LifecycleAt(time.Time{})
-	c.Assert(func() {
-		c.Log(lifecycle.String())
-	}, qt.PanicMatches, "invalid lifecycle.*")
-}


### PR DESCRIPTION
Previously we paniced with the message:

    panic: invalid lifecycle (1)

which is not helpful and doesn't give any indication about what went wrong or how to fix it.

This new error message should be a lot clearer and help users to realise their mistake.

I see no reason why we have to panic when we get an unreleased version, so that has been removed.