### PR TITLE
fix: merge operations from duplicate paths

### DIFF
--- a/collator_test.go
+++ b/collator_test.go
@@ -217,3 +217,31 @@ func TestCollateMergingResources(t *testing.T) {
 	result := collator.Result()
 	c.Assert(result.Paths["/orgs/{org_id}/projects/{project_id}"].Delete.Responses["204"], qt.IsNotNil)
 }
+
+func TestCollateOperationsOnSamePath(t *testing.T) {
+	c := qt.New(t)
+	collator := vervet.NewCollator(vervet.UseFirstRoute(true))
+	examples1, err := vervet.LoadResourceVersions(testdata.Path("operation-change/_examples"))
+	c.Assert(err, qt.IsNil)
+	examples1v, err := examples1.At("2021-06-15~experimental")
+	c.Assert(err, qt.IsNil)
+
+	examples2, err := vervet.LoadResourceVersions(testdata.Path("operation-change/_examples2"))
+	c.Assert(err, qt.IsNil)
+	examples2v, err := examples2.At("2021-06-15~experimental")
+	c.Assert(err, qt.IsNil)
+
+	err = collator.Collate(examples1v)
+	c.Assert(err, qt.IsNil)
+	err = collator.Collate(examples2v)
+	c.Assert(err, qt.IsNil)
+
+	result := collator.Result()
+
+	c.Assert(result.Paths["/examples/hello-world"].Get, qt.Not(qt.IsNil))
+	c.Assert(result.Paths["/examples/hello-world"].Get.Description, qt.Contains, " - from example 1")
+	c.Assert(result.Paths["/examples/hello-world"].Post, qt.Not(qt.IsNil))
+	c.Assert(result.Paths["/examples/hello-world"].Post.Description, qt.Contains, " - from example 1")
+	c.Assert(result.Paths["/examples/hello-world"].Put, qt.Not(qt.IsNil))
+	c.Assert(result.Paths["/examples/hello-world"].Put.Description, qt.Contains, " - from example 2")
+}

--- a/internal/scraper/gcs_scraper_test.go
+++ b/internal/scraper/gcs_scraper_test.go
@@ -24,8 +24,8 @@ func TestGCSScraper(t *testing.T) {
 	tests := []struct {
 		service, version, digest string
 	}{
-		{"petfood", "2021-09-01", "sha256:I20cAQ3VEjDrY7O0B678yq+0pYN2h3sxQy7vmdlo4+w="},
-		{"animals", "2021-10-16", "sha256:P1FEFvnhtxJSqXr/p6fMNKE+HYwN6iwKccBGHIVZbyg="},
+		{"petfood", "2021-09-01", "sha256:zCgJaPeR8R21wsAlYn46xO6NE3XJiyFtLnYrP4DpM3U="},
+		{"animals", "2021-10-16", "sha256:hcv2i7awT6CcSCecw9WrYBokFyzYNVaQArGgqHqdj7s="},
 	}
 
 	cfg := &config.ServerConfig{
@@ -95,8 +95,8 @@ func TestGCSScraperCollation(t *testing.T) {
 	tests := []struct {
 		service, version, digest string
 	}{
-		{"petfood", "2021-09-01", "sha256:I20cAQ3VEjDrY7O0B678yq+0pYN2h3sxQy7vmdlo4+w="},
-		{"animals", "2021-10-16", "sha256:P1FEFvnhtxJSqXr/p6fMNKE+HYwN6iwKccBGHIVZbyg="},
+		{"petfood", "2021-09-01", "sha256:zCgJaPeR8R21wsAlYn46xO6NE3XJiyFtLnYrP4DpM3U="},
+		{"animals", "2021-10-16", "sha256:hcv2i7awT6CcSCecw9WrYBokFyzYNVaQArGgqHqdj7s="},
 	}
 
 	cfg := &config.ServerConfig{

--- a/internal/scraper/s3_scraper_test.go
+++ b/internal/scraper/s3_scraper_test.go
@@ -24,8 +24,8 @@ func TestS3Scraper(t *testing.T) {
 	tests := []struct {
 		name, version, digest string
 	}{
-		{"petfood", "2021-09-01", "sha256:I20cAQ3VEjDrY7O0B678yq+0pYN2h3sxQy7vmdlo4+w="},
-		{"animals", "2021-10-16", "sha256:P1FEFvnhtxJSqXr/p6fMNKE+HYwN6iwKccBGHIVZbyg="},
+		{"petfood", "2021-09-01", "sha256:zCgJaPeR8R21wsAlYn46xO6NE3XJiyFtLnYrP4DpM3U="},
+		{"animals", "2021-10-16", "sha256:hcv2i7awT6CcSCecw9WrYBokFyzYNVaQArGgqHqdj7s="},
 	}
 
 	cfg := &config.ServerConfig{
@@ -90,9 +90,9 @@ func TestS3ScraperCollation(t *testing.T) {
 	tests := []struct {
 		name, version, digest string
 	}{{
-		"petfood", "2021-09-01", "sha256:I20cAQ3VEjDrY7O0B678yq+0pYN2h3sxQy7vmdlo4+w=",
+		"petfood", "2021-09-01", "sha256:zCgJaPeR8R21wsAlYn46xO6NE3XJiyFtLnYrP4DpM3U=",
 	}, {
-		"animals", "2021-10-16", "sha256:P1FEFvnhtxJSqXr/p6fMNKE+HYwN6iwKccBGHIVZbyg=",
+		"animals", "2021-10-16", "sha256:hcv2i7awT6CcSCecw9WrYBokFyzYNVaQArGgqHqdj7s=",
 	}}
 
 	cfg := &config.ServerConfig{

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -31,16 +31,16 @@ var (
 	petfood = &testService{
 		versions: []string{"2021-09-01", "2021-09-16"},
 		contents: map[string]string{
-			"2021-09-01": `{"paths":{"/crickets": {}}}`,
-			"2021-09-16": `{"paths":{"/crickets": {}, "/kibble": {}}}`,
+			"2021-09-01": `{"paths":{"/crickets": {"get": {}}}}`,
+			"2021-09-16": `{"paths":{"/crickets": {"get": {}}, "/kibble": {"get": {}}}}`,
 		},
 	}
 	animals = &testService{
 		versions: []string{"2021-01-01", "2021-10-01", "2021-10-16"},
 		contents: map[string]string{
-			"2021-01-01": `{"paths":{"/legacy": {}}}`,
-			"2021-10-01": `{"paths":{"/geckos": {}}}`,
-			"2021-10-16": `{"paths":{"/geckos": {}, "/puppies": {}}}`,
+			"2021-01-01": `{"paths":{"/legacy": {"get": {}}}}`,
+			"2021-10-01": `{"paths":{"/geckos": {"get": {}}}}`,
+			"2021-10-16": `{"paths":{"/geckos": {"get": {}}, "/puppies": {"get": {}}}}`,
 		},
 	}
 )
@@ -85,8 +85,8 @@ func TestScraper(t *testing.T) {
 	tests := []struct {
 		name, version, digest string
 	}{
-		{"petfood", "2021-09-01", "sha256:I20cAQ3VEjDrY7O0B678yq+0pYN2h3sxQy7vmdlo4+w="},
-		{"animals", "2021-10-16", "sha256:P1FEFvnhtxJSqXr/p6fMNKE+HYwN6iwKccBGHIVZbyg="},
+		{"petfood", "2021-09-01", "sha256:zCgJaPeR8R21wsAlYn46xO6NE3XJiyFtLnYrP4DpM3U="},
+		{"animals", "2021-10-16", "sha256:hcv2i7awT6CcSCecw9WrYBokFyzYNVaQArGgqHqdj7s="},
 	}
 
 	cfg := &config.ServerConfig{

--- a/testdata/operation-change/_examples/2021-06-15/spec.yaml
+++ b/testdata/operation-change/_examples/2021-06-15/spec.yaml
@@ -1,0 +1,52 @@
+---
+openapi: 3.0.3
+x-snyk-api-stability: beta
+info:
+  title: Registry
+  version: 3.0.0
+servers:
+  - url: /api/v3
+    description: Snyk Registry
+paths:
+  /examples/hello-world:
+    post:
+      description: Create a single result from the hello-world example - from example 1
+      operationId: helloWorldCreate
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                attributes:
+                  type: object
+                  properties:
+                    message:
+                      type: string
+                    betaField:
+                      type: string
+                  additionalProperties: false
+                  required: ['message', 'betaField']
+              additionalProperties: false
+              required: ['attributes']
+      responses:
+        '201':
+          description: 'A hello world entity being requested is returned'
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                required: ['jsonapi', 'data', 'links']
+                additionalProperties: false
+    get:
+      description: Get a list of hello-worlds example - from example 1
+      operationId: helloWorldGetList
+      responses:
+        '200':
+          description: 'A hello world entity being requested is returned'
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                required: ['jsonapi', 'data', 'links']
+                additionalProperties: false

--- a/testdata/operation-change/_examples2/2021-06-15/spec.yaml
+++ b/testdata/operation-change/_examples2/2021-06-15/spec.yaml
@@ -1,0 +1,69 @@
+---
+openapi: 3.0.3
+x-snyk-api-stability: beta
+info:
+  title: Registry
+  version: 3.0.0
+servers:
+  - url: /api/v3
+    description: Snyk Registry
+paths:
+  /examples/hello-world:
+    post:
+      description: Create a single result from the hello-world example - from example 2
+      operationId: helloWorldCreate
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                attributes:
+                  type: object
+                  properties:
+                    message:
+                      type: string
+                    betaField:
+                      type: string
+                  additionalProperties: false
+                  required: ['message', 'betaField']
+              additionalProperties: false
+              required: ['attributes']
+      responses:
+        '201':
+          description: 'A hello world entity being requested is returned'
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                required: ['jsonapi', 'data', 'links']
+                additionalProperties: false
+    put:
+      description: Force create a hello-world example - from example 2
+      operationId: helloWorldForceCreate
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                attributes:
+                  type: object
+                  properties:
+                    message:
+                      type: string
+                    betaField:
+                      type: string
+                  additionalProperties: false
+                  required: ['message', 'betaField']
+              additionalProperties: false
+              required: ['attributes']
+      responses:
+        '201':
+          description: 'A hello world entity being requested is returned'
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                required: ['jsonapi', 'data', 'links']
+                additionalProperties: false


### PR DESCRIPTION
We were previously overriding whole paths if they were defined in a newer version. This means that operations are marked as sunset if they are not redefined in the newer spec. This is surprising behaviour.

This patch will mean that we merge all operations, so future versions do not need to redeclare operations on each path for them to remain current.

Running against this latest version will rewrite already generated specs.