### PR TITLE
feat: do not collate sunset paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 APP:=vervet
 GO_BIN=$(shell pwd)/.bin/go
 
-SHELL:=env PATH=$(GO_BIN):$(PATH) $(SHELL)
+SHELL:=env PATH="$(GO_BIN):$(PATH)" $(SHELL)
 
 GOCI_LINT_V?=v1.54.2
 


### PR DESCRIPTION
This PR introduces a feature to filter out API paths marked as sunset eligible in the Vervet tool's collation process. It ensures that paths with the x-snyk-sunset-eligible attribute, dated earlier than the current date, are excluded from the final collated specifications.