### PR TITLE
feat: breaking changes check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 APP:=vervet
 GO_BIN=$(shell pwd)/.bin/go
 
-SHELL:=env PATH=$(GO_BIN):$(PATH) $(SHELL)
+SHELL:=env PATH="$(GO_BIN):$(PATH)" $(SHELL)
 
 GOCI_LINT_V?=v1.59.1
 

--- a/internal/simplebuild/build.go
+++ b/internal/simplebuild/build.go
@@ -19,7 +19,6 @@ import (
 
 func Build(ctx context.Context, project *config.Project) error {
 	for _, apiConfig := range project.APIs {
-
 		fmt.Printf("Processing API: %s\n", apiConfig.Name)
 
 		operations, err := LoadPaths(ctx, apiConfig)


### PR DESCRIPTION
This PR adds a check to the simple build flow to ensure that all sequential versions introduce breaking changes. 

If a version does not introduce a breaking change then that version should be "rolled into" the previous version as it is non breaking and the changes can be added in without breaking existing flows.