### PR TITLE
chore: upgrade go within dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.22.3
+ARG GO_VERSION=1.22.5
 
 ###############
 # Build stage #


### PR DESCRIPTION
This PR attempts to upgrade the go version used within the Dockerfile during the build process