### PR TITLE
feat: annotate operations with stability level

### DIFF
--- a/internal/simplebuild/build.go
+++ b/internal/simplebuild/build.go
@@ -294,12 +294,18 @@ func (vs VersionSet) Annotate() {
 
 	for idx, op := range vs {
 		if op.Operation.Extensions == nil {
-			op.Operation.Extensions = make(map[string]interface{}, 6)
+			op.Operation.Extensions = make(map[string]interface{}, 8)
 		}
 		op.Operation.Extensions[vervet.ExtSnykApiResource] = op.ResourceName
 		op.Operation.Extensions[vervet.ExtSnykApiVersion] = op.Version.String()
 		op.Operation.Extensions[vervet.ExtSnykApiReleases] = releases
 		op.Operation.Extensions[vervet.ExtSnykApiLifecycle] = op.Version.LifecycleAt(time.Time{}).String()
+
+		if op.Version.Stability == vervet.StabilityBeta {
+			op.Operation.Extensions[vervet.ExtApiStabilityLevel] = "beta"
+			op.Operation.Extensions[vervet.ExtSnykApiStability] = "beta"
+		}
+
 		if idx < (count - 1) {
 			laterVersion := vs[idx+1].Version
 			// Sanity check the later version actually deprecates this one

--- a/internal/simplebuild/build.go
+++ b/internal/simplebuild/build.go
@@ -300,11 +300,8 @@ func (vs VersionSet) Annotate() {
 		op.Operation.Extensions[vervet.ExtSnykApiVersion] = op.Version.String()
 		op.Operation.Extensions[vervet.ExtSnykApiReleases] = releases
 		op.Operation.Extensions[vervet.ExtSnykApiLifecycle] = op.Version.LifecycleAt(time.Time{}).String()
-
-		if op.Version.Stability == vervet.StabilityBeta {
-			op.Operation.Extensions[vervet.ExtApiStabilityLevel] = "beta"
-			op.Operation.Extensions[vervet.ExtSnykApiStability] = "beta"
-		}
+		op.Operation.Extensions[vervet.ExtApiStabilityLevel] = op.Version.Stability.String()
+		op.Operation.Extensions[vervet.ExtSnykApiStability] = op.Version.Stability.String()
 
 		if idx < (count - 1) {
 			laterVersion := vs[idx+1].Version

--- a/internal/simplebuild/build_test.go
+++ b/internal/simplebuild/build_test.go
@@ -465,7 +465,6 @@ func TestAnnotate(t *testing.T) {
 			[]string{"2024-01-01", "2024-02-01~beta", "2024-03-01"},
 		)
 
-		// Check stability level for beta version
 		c.Assert(vs[1].Operation.Extensions[vervet.ExtApiStabilityLevel], qt.Equals, "beta")
 		c.Assert(vs[1].Operation.Extensions[vervet.ExtSnykApiStability], qt.Equals, "beta")
 	})
@@ -498,7 +497,6 @@ func TestAnnotate(t *testing.T) {
 		c.Assert(vs[2].Operation.Extensions[vervet.ExtSnykDeprecatedBy], qt.IsNil)
 		c.Assert(vs[2].Operation.Extensions[vervet.ExtSnykSunsetEligible], qt.IsNil)
 
-		// Check stability level for beta version
 		c.Assert(vs[0].Operation.Extensions["x-stability-level"], qt.Equals, "beta")
 		c.Assert(vs[0].Operation.Extensions["x-snyk-api-stability"], qt.Equals, "beta")
 	})

--- a/internal/simplebuild/build_test.go
+++ b/internal/simplebuild/build_test.go
@@ -424,6 +424,10 @@ func TestAnnotate(t *testing.T) {
 		c.Assert(vs[1].Operation.Extensions[vervet.ExtSnykApiResource], qt.Equals, "foo")
 		c.Assert(vs[2].Operation.Extensions[vervet.ExtSnykApiVersion], qt.Equals, "2024-03-01")
 		c.Assert(vs[2].Operation.Extensions[vervet.ExtSnykApiResource], qt.Equals, "bar")
+
+		// Check stability level for beta version
+		c.Assert(vs[1].Operation.Extensions[vervet.ExtApiStabilityLevel], qt.Equals, "beta")
+		c.Assert(vs[1].Operation.Extensions[vervet.ExtSnykApiStability], qt.Equals, "beta")
 	})
 
 	c.Run("adds a list of all other versions", func(c *qt.C) {
@@ -460,6 +464,10 @@ func TestAnnotate(t *testing.T) {
 			qt.DeepEquals,
 			[]string{"2024-01-01", "2024-02-01~beta", "2024-03-01"},
 		)
+
+		// Check stability level for beta version
+		c.Assert(vs[1].Operation.Extensions[vervet.ExtApiStabilityLevel], qt.Equals, "beta")
+		c.Assert(vs[1].Operation.Extensions[vervet.ExtSnykApiStability], qt.Equals, "beta")
 	})
 
 	c.Run("adds deprecation annotations on older versions", func(c *qt.C) {
@@ -489,6 +497,10 @@ func TestAnnotate(t *testing.T) {
 		c.Assert(vs[1].Operation.Extensions[vervet.ExtSnykSunsetEligible], qt.Equals, "2024-08-29")
 		c.Assert(vs[2].Operation.Extensions[vervet.ExtSnykDeprecatedBy], qt.IsNil)
 		c.Assert(vs[2].Operation.Extensions[vervet.ExtSnykSunsetEligible], qt.IsNil)
+
+		// Check stability level for beta version
+		c.Assert(vs[0].Operation.Extensions["x-stability-level"], qt.Equals, "beta")
+		c.Assert(vs[0].Operation.Extensions["x-snyk-api-stability"], qt.Equals, "beta")
 	})
 }
 

--- a/resource.go
+++ b/resource.go
@@ -19,6 +19,10 @@ const (
 	// spec with its API release stability level.
 	ExtSnykApiStability = "x-snyk-api-stability"
 
+	// ExtApiStability is used to annotate a path in a compiled OpenAPI spec
+	// with its API release stability level.
+	ExtApiStabilityLevel = "x-stability-level"
+
 	// ExtSnykApiLifecycle is used to annotate compiled OpenAPI with lifecycle
 	// stage: releases, deprecated or sunset. It is applied at the top-level as
 	// well as per-operation.


### PR DESCRIPTION
This PR attempts to annotate the operations added during the new build process with the x-stability-level and x-snyk-api-stability annotations. These annotations are meant for the client to be able to tell which stability the requested path is at.