### PR TITLE
fix: map x-stability value to a parsable value

### DIFF
--- a/internal/simplebuild/build.go
+++ b/internal/simplebuild/build.go
@@ -337,7 +337,7 @@ func (vs VersionSet) Annotate() {
 		op.Operation.Extensions[vervet.ExtSnykApiVersion] = op.Version.String()
 		op.Operation.Extensions[vervet.ExtSnykApiReleases] = releases
 		op.Operation.Extensions[vervet.ExtSnykApiLifecycle] = op.Version.LifecycleAt(time.Time{}).String()
-		op.Operation.Extensions[vervet.ExtApiStabilityLevel] = op.Version.Stability.String()
+		op.Operation.Extensions[vervet.ExtApiStabilityLevel] = MapStabilityLevel(op.Version.Stability)
 		op.Operation.Extensions[vervet.ExtSnykApiStability] = op.Version.Stability.String()
 
 		if idx < (count - 1) {
@@ -352,6 +352,18 @@ func (vs VersionSet) Annotate() {
 				op.Operation.Extensions[vervet.ExtSnykSunsetEligible] = sunsetDate.Format("2006-01-02")
 			}
 		}
+	}
+}
+
+// MapStabilityLevel maps the vervet stability level to the x-API stability level header.
+func MapStabilityLevel(s vervet.Stability) string {
+	switch s {
+	case vervet.StabilityGA:
+		return "stable"
+	case vervet.StabilityBeta:
+		return "beta"
+	default:
+		return ""
 	}
 }
 

--- a/internal/simplebuild/build_test.go
+++ b/internal/simplebuild/build_test.go
@@ -700,3 +700,34 @@ func compareDocs(a, b simplebuild.VersionedDoc) int {
 func compareDates(a, b time.Time) int {
 	return a.Compare(b)
 }
+
+func TestMapStabilityLevel(t *testing.T) {
+	tests := []struct {
+		name string
+		args vervet.Stability
+		want string
+	}{
+		{
+			name: "stable",
+			args: vervet.StabilityGA,
+			want: "stable",
+		},
+		{
+			name: "beta",
+			args: vervet.StabilityBeta,
+			want: "beta",
+		},
+		{
+			name: "defaults to blank",
+			args: vervet.StabilityExperimental,
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := simplebuild.MapStabilityLevel(tt.args); got != tt.want {
+				t.Errorf("MapStabilityLevel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
context: 
the x-stability-level values dont map directly to vervet stability levels; this PR maps "ga" to "stable"

If we dont fix this, tools like oas-diff start failing the generated spec