### PR TITLE
fix: filters out wip versions from simplebuild collation

### DIFF
--- a/internal/simplebuild/build.go
+++ b/internal/simplebuild/build.go
@@ -145,7 +145,7 @@ type VersionedDoc struct {
 type DocSet []VersionedDoc
 
 func (ops Operations) Build(startVersion vervet.Version) DocSet {
-	filteredOps := filterOutExperimentalVersions(ops)
+	filteredOps := filterBetaAndGAVersions(ops)
 	versionDates := filteredOps.VersionDates()
 	versionDates = filterVersionByStartDate(versionDates, startVersion.Date)
 	output := make(DocSet, len(versionDates))
@@ -165,12 +165,13 @@ func (ops Operations) Build(startVersion vervet.Version) DocSet {
 	return output
 }
 
-func filterOutExperimentalVersions(ops Operations) Operations {
+func filterBetaAndGAVersions(ops Operations) Operations {
 	filteredOps := make(Operations, len(ops))
 	for opKey, versionSet := range ops {
 		filteredVersionSet := VersionSet{}
 		for _, versionedOp := range versionSet {
-			if versionedOp.Version.Stability == vervet.StabilityExperimental {
+			if versionedOp.Version.Stability != vervet.StabilityGA &&
+				versionedOp.Version.Stability != vervet.StabilityBeta {
 				continue
 			}
 			filteredVersionSet = append(filteredVersionSet, versionedOp)

--- a/internal/simplebuild/build_test.go
+++ b/internal/simplebuild/build_test.go
@@ -471,6 +471,82 @@ func TestBuild(t *testing.T) {
 		c.Assert(output[2].Doc.Paths.Value("/experimental-path-before-pivot-date"), qt.IsNil)
 		c.Assert(output[2].Doc.Paths.Value("/experimental-path"), qt.IsNil)
 	})
+	c.Run("wip version are filtered out", func(c *qt.C) {
+		versionBetaA := vervet.MustParseVersion("2024-01-01~beta")
+		versionGA := vervet.MustParseVersion("2024-01-02")
+		versionBetaB := vervet.MustParseVersion("2024-01-03~beta")
+		versionWip := vervet.MustParseVersion("2024-01-04~wip")
+		versionWipBeforePivotDate := vervet.MustParseVersion("2023-01-01~wip")
+
+		getFoo := openapi3.NewOperation()
+		postFoo := openapi3.NewOperation()
+		getBar := openapi3.NewOperation()
+
+		ops := simplebuild.Operations{
+			simplebuild.OpKey{
+				Path:   "/foo",
+				Method: "GET",
+			}: simplebuild.VersionSet{simplebuild.VersionedOp{
+				Version:      versionGA,
+				Operation:    getFoo,
+				ResourceName: "foo",
+			}},
+			simplebuild.OpKey{
+				Path:   "/foo",
+				Method: "POST",
+			}: simplebuild.VersionSet{simplebuild.VersionedOp{
+				Version:      versionBetaB,
+				Operation:    postFoo,
+				ResourceName: "foo",
+			}},
+			simplebuild.OpKey{
+				Path:   "/bar",
+				Method: "GET",
+			}: simplebuild.VersionSet{simplebuild.VersionedOp{
+				Version:      versionBetaA,
+				Operation:    getBar,
+				ResourceName: "bar",
+			}},
+			simplebuild.OpKey{
+				Path:   "/wip-path",
+				Method: "GET",
+			}: simplebuild.VersionSet{simplebuild.VersionedOp{
+				Version:      versionWip,
+				Operation:    openapi3.NewOperation(),
+				ResourceName: "wip-path",
+			}},
+			simplebuild.OpKey{
+				Path:   "/wip-path-before-pivot-date",
+				Method: "GET",
+			}: simplebuild.VersionSet{simplebuild.VersionedOp{
+				Version:      versionWipBeforePivotDate,
+				Operation:    openapi3.NewOperation(),
+				ResourceName: "wip-path-before-pivot-date",
+			}},
+		}
+		output := ops.Build(vervet.MustParseVersion("2024-01-01"))
+
+		slices.SortFunc(output, compareDocs)
+
+		c.Assert(output, qt.HasLen, 3)
+
+		c.Assert(output[0].VersionDate, qt.Equals, versionBetaA.Date)
+		c.Assert(output[0].Doc.Paths.Value("/foo"), qt.IsNil)
+		c.Assert(output[0].Doc.Paths.Value("/bar").Get, qt.Equals, getBar)
+		c.Assert(output[0].Doc.Paths.Value("/wip-path-before-pivot-date"), qt.IsNil)
+
+		c.Assert(output[1].VersionDate, qt.Equals, versionGA.Date)
+		c.Assert(output[1].Doc.Paths.Value("/foo").Get, qt.Equals, getFoo)
+		c.Assert(output[1].Doc.Paths.Value("/foo").Post, qt.IsNil)
+		c.Assert(output[0].Doc.Paths.Value("/bar").Get, qt.Equals, getBar)
+
+		c.Assert(output[2].VersionDate, qt.Equals, versionBetaB.Date)
+		c.Assert(output[2].Doc.Paths.Value("/foo").Get, qt.Equals, getFoo)
+		c.Assert(output[2].Doc.Paths.Value("/foo").Post, qt.Equals, postFoo)
+		c.Assert(output[2].Doc.Paths.Value("/bar").Get, qt.Equals, getBar)
+		c.Assert(output[2].Doc.Paths.Value("/wip-path-before-pivot-date"), qt.IsNil)
+		c.Assert(output[2].Doc.Paths.Value("/wip-path"), qt.IsNil)
+	})
 }
 
 func TestAnnotate(t *testing.T) {


### PR DESCRIPTION
context: https://snyk.slack.com/archives/C01HY16GZTR/p1728475585279769

need to filter out experimental and wip versions from the single spec