### PR TITLE
fix: get document version from filename to fix backstage cmds

### DIFF
--- a/document.go
+++ b/document.go
@@ -197,11 +197,9 @@ func (d *Document) LoadReference(relPath, refPath string, target interface{}) (_
 
 // Version returns the version of the document.
 func (d *Document) Version() (Version, error) {
-	vs, err := ExtensionString(d.Extensions, ExtSnykApiVersion)
-	if err != nil {
-		return Version{}, err
-	}
-	return ParseVersion(vs)
+	versionDir := filepath.Dir(d.path)
+	versionStr := filepath.Base(versionDir)
+	return ParseVersion(versionStr)
 }
 
 // Lifecycle returns the lifecycle of the document.

--- a/document_test.go
+++ b/document_test.go
@@ -19,3 +19,13 @@ func TestNewDocumentFile(t *testing.T) {
 	c.Assert(doc.Components.Schemas["HelloWorld"], qt.Not(qt.IsNil))
 	c.Assert(doc.Validate(context.TODO()), qt.IsNil)
 }
+
+func TestDocumentVersion(t *testing.T) {
+	c := qt.New(t)
+	doc, err := vervet.NewDocumentFile(testdata.Path("resources/_examples/hello-world/2021-06-01/spec.yaml"))
+	c.Assert(err, qt.IsNil)
+
+	version, err := doc.Version()
+	c.Assert(err, qt.IsNil)
+	c.Assert(version, qt.Equals, vervet.MustParseVersion("2021-06-01"))
+}


### PR DESCRIPTION
Previously we were reading the document version from the top level x-snyk-api-version extension. This extension does not exist on documents past the pivot date as versions are done per endpoint. This resulted in all backstage commands failing. (eg vervet backstage update-catalog)

This information is available in the file path, so instead of poluting our new documents with this extension we can read it from there instead. This change is backwards compatable with older specs.