### PR TITLE
fix: update versionware to consider pivot date

### DIFF
--- a/internal/cmd/backstage.go
+++ b/internal/cmd/backstage.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/snyk/vervet/v8"
 	"github.com/snyk/vervet/v8/config"
 	"github.com/snyk/vervet/v8/internal/backstage"
 )
@@ -32,8 +33,8 @@ var BackstageCommand = cli.Command{
 				Aliases: []string{"P"},
 				Usage: fmt.Sprintf(
 					"Pivot version after which new strategy versioning is used."+
-						" Flag for testing only, recommend to use the default date(%s)", defaultPivotDate.String()),
-				Value: defaultPivotDate.String(),
+						" Flag for testing only, recommend to use the default date(%s)", vervet.DefaultPivotDate.String()),
+				Value: vervet.DefaultPivotDate.String(),
 			},
 		},
 		Action: UpdateCatalog,
@@ -51,8 +52,8 @@ var BackstageCommand = cli.Command{
 				Aliases: []string{"P"},
 				Usage: fmt.Sprintf(
 					"Pivot version after which new strategy versioning is used."+
-						" Flag for testing only, recommend to use the default date(%s)", defaultPivotDate.String()),
-				Value: defaultPivotDate.String(),
+						" Flag for testing only, recommend to use the default date(%s)", vervet.DefaultPivotDate.String()),
+				Value: vervet.DefaultPivotDate.String(),
 			},
 		},
 		Action: PreviewCatalog,

--- a/internal/cmd/compiler.go
+++ b/internal/cmd/compiler.go
@@ -12,7 +12,6 @@ import (
 	"github.com/snyk/vervet/v8/internal/simplebuild"
 )
 
-var defaultPivotDate = vervet.MustParseVersion("2024-10-15")
 var defaultVersioningUrl = "https://api.snyk.io/rest/openapi"
 
 var pivotDateCLIFlagName = "pivot-version"
@@ -34,8 +33,8 @@ var buildFlags = []cli.Flag{
 		Aliases: []string{"P"},
 		Usage: fmt.Sprintf(
 			"Pivot version after which new strategy versioning is used."+
-				" Flag for testing only, recommend to use the default date(%s)", defaultPivotDate.String()),
-		Value: defaultPivotDate.String(),
+				" Flag for testing only, recommend to use the default date(%s)", vervet.DefaultPivotDate.String()),
+		Value: vervet.DefaultPivotDate.String(),
 	},
 	&cli.StringFlag{
 		Name:    versioningUrlCLIFlagName,

--- a/versionware/handler.go
+++ b/versionware/handler.go
@@ -69,9 +69,18 @@ func (h *Handler) HandleErrors(errFunc VersionErrorHandler) {
 // Resolve returns the resolved version and its associated http.Handler for the
 // requested version.
 func (h *Handler) Resolve(requested vervet.Version) (*vervet.Version, http.Handler, error) {
-	resolvedVersion, err := h.index.ResolveForBuild(requested)
-	if err != nil {
-		return nil, nil, err
+	var resolvedVersion vervet.Version
+	var err error
+	if requested.Date.Compare(vervet.DefaultPivotDate.Date) < 0 {
+		resolvedVersion, err = h.index.ResolveForBuild(requested)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		resolvedVersion, err = h.index.ResolveGAorBetaStability(requested)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 	return &resolvedVersion, h.handlers[resolvedVersion], nil
 }

--- a/versionware/handler_test.go
+++ b/versionware/handler_test.go
@@ -80,6 +80,18 @@ func TestHandler(t *testing.T) {
 			_, err := w.Write([]byte("sept"))
 			c.Assert(err, qt.IsNil)
 		}),
+	}, {
+		Version: vervet.MustParseVersion("2024-10-15"),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := w.Write([]byte("on pivot date"))
+			c.Assert(err, qt.IsNil)
+		}),
+	}, {
+		Version: vervet.MustParseVersion("2024-10-20"),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := w.Write([]byte("after pivot date"))
+			c.Assert(err, qt.IsNil)
+		}),
 	}}...)
 	tests := []struct {
 		requested, resolved string
@@ -107,6 +119,105 @@ func TestHandler(t *testing.T) {
 		"2021-08-01~beta", "2021-08-01~beta", "aug beta", 200,
 	}, {
 		"2021-09-01~beta", "2021-09-01", "sept", 200,
+	}, {
+		"2024-10-14", "2021-11-01", "nov", 200,
+	}, {
+		"2024-10-14~beta", "2021-11-01", "nov", 200,
+	}, {
+		"2024-10-14~experimental", "2021-11-01", "nov", 200,
+	}, {
+		"2024-10-15", "2024-10-15", "on pivot date", 200,
+	}, {
+		"2024-10-16", "2024-10-15", "on pivot date", 200,
+	}, {
+		"2024-10-20", "2024-10-20", "after pivot date", 200,
+	}, {
+		"2024-10-20~beta", "", "Not Found\n", 404,
+	}, {
+		"2024-10-20~experimental", "", "Not Found\n", 404,
+	}}
+	for i, test := range tests {
+		c.Run(fmt.Sprintf("%d requested %s resolved %s", i, test.requested, test.resolved), func(c *qt.C) {
+			s := httptest.NewServer(h)
+			c.Cleanup(s.Close)
+			req, err := http.NewRequest("GET", s.URL+"?version="+test.requested, nil)
+			c.Assert(err, qt.IsNil)
+			resp, err := s.Client().Do(req)
+			c.Assert(err, qt.IsNil)
+			defer resp.Body.Close()
+			c.Assert(resp.StatusCode, qt.Equals, test.status)
+			contents, err := io.ReadAll(resp.Body)
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(contents), qt.Equals, test.contents)
+		})
+	}
+}
+
+func TestHandler_BetaEndpoints(t *testing.T) {
+	c := qt.New(t)
+	h := versionware.NewHandler([]versionware.VersionHandler{{
+		Version: vervet.MustParseVersion("2021-08-01~beta"),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := w.Write([]byte("aug beta"))
+			c.Assert(err, qt.IsNil)
+		}),
+	}, {
+		Version: vervet.MustParseVersion("2021-10-01~beta"),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := w.Write([]byte("oct beta"))
+			c.Assert(err, qt.IsNil)
+		}),
+	}, {
+		Version: vervet.MustParseVersion("2021-11-01~experimental"),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := w.Write([]byte("nov experimental"))
+			c.Assert(err, qt.IsNil)
+		}),
+	}, {
+		Version: vervet.MustParseVersion("2024-10-15~beta"),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := w.Write([]byte("beta on pivot date"))
+			c.Assert(err, qt.IsNil)
+		}),
+	}, {
+		Version: vervet.MustParseVersion("2024-10-20~beta"),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := w.Write([]byte("beta after pivot date"))
+			c.Assert(err, qt.IsNil)
+		}),
+	}, {
+		Version: vervet.MustParseVersion("2024-10-25"),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := w.Write([]byte("ga after pivot date"))
+			c.Assert(err, qt.IsNil)
+		}),
+	}}...)
+	tests := []struct {
+		requested, resolved string
+		contents            string
+		status              int
+	}{{
+		"2021-07-31~beta", "", "Not Found\n", 404,
+	}, {
+		"2021-09-16~beta", "2021-08-01~beta", "aug beta", 200,
+	}, {
+		"2021-10-01~beta", "2021-10-01~beta", "oct beta", 200,
+	}, {
+		"2021-11-05~experimental", "2021-11-01~experimental", "nov experimental", 200,
+	}, {
+		"2024-10-15", "2024-10-15~beta", "beta on pivot date", 200,
+	}, {
+		"2024-10-15~beta", "", "Not Found\n", 404,
+	}, {
+		"2024-10-15~experimental", "", "Not Found\n", 404,
+	}, {
+		"2024-10-16", "2024-10-15~beta", "beta on pivot date", 200,
+	}, {
+		"2024-10-20", "2024-10-20~beta", "beta after pivot date", 200,
+	}, {
+		"2024-10-21", "2024-10-20~beta", "beta after pivot date", 200,
+	}, {
+		"2024-10-26", "2024-10-25", "ga after pivot date", 200,
 	}}
 	for i, test := range tests {
 		c.Run(fmt.Sprintf("%d requested %s resolved %s", i, test.requested, test.resolved), func(c *qt.C) {


### PR DESCRIPTION
- fixes resolution for beta endpoints, post pivot date
- beta endpoints are now folded into the GA spec
- not resolving `beta` and `experimental` versions post pivot date