### PR TITLE
fix: nil check for config output

### DIFF
--- a/config/api.go
+++ b/config/api.go
@@ -76,6 +76,9 @@ type Output struct {
 // EffectivePaths returns a slice of effective configured output paths, whether
 // a single or multiple output paths have been configured.
 func (o *Output) ResolvePaths() []string {
+	if o == nil {
+		return []string{}
+	}
 	if o.Path != "" {
 		return []string{o.Path}
 	}

--- a/config/api_test.go
+++ b/config/api_test.go
@@ -1,0 +1,45 @@
+package config_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/snyk/vervet/v8/config"
+)
+
+func TestOutput_ResolvePaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject *config.Output
+		want    []string
+	}{
+		{
+			name:    "nil",
+			subject: nil,
+			want:    []string{},
+		},
+		{
+			name: "returns path if exists",
+			subject: &config.Output{
+				Path:  "path",
+				Paths: []string{"path1", "path2"},
+			},
+			want: []string{"path"},
+		},
+		{
+			name: "return paths if path is empty",
+			subject: &config.Output{
+				Path:  "",
+				Paths: []string{"path1", "path2"},
+			},
+			want: []string{"path1", "path2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.subject.ResolvePaths(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ResolvePaths() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/backstage.go
+++ b/internal/cmd/backstage.go
@@ -190,6 +190,10 @@ func processCatalog(ctx *cli.Context, w io.Writer) error {
 	for _, apiName := range apiNames {
 		apiConf := proj.APIs[apiName]
 		outputPaths := apiConf.Output.ResolvePaths()
+		if len(outputPaths) == 0 {
+			log.Printf("API %q has no output paths, this command will have no effect", apiName)
+			continue
+		}
 		for _, outputPath := range outputPaths {
 			outputPath = filepath.Join(projectDir, outputPath)
 			if matchPath(outputPath) {


### PR DESCRIPTION
`update-catalog` fails with a nil pointer if output is not set 
```
$ go run github.com/snyk/vervet/v8/cmd/vervet@v8.7.2 backstage update-catalog
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x1008ef650]

goroutine 1 [running]:
github.com/snyk/vervet/v8/config.(*Output).ResolvePaths(...)
	/Users/jatin/go/pkg/mod/github.com/snyk/vervet/v8@v8.7.2/config/api.go:79
github.com/snyk/vervet/v8/internal/cmd.processCatalog(0x140001c1e80, {0x0, 0x0})
	/Users/jatin/go/pkg/mod/github.com/snyk/vervet/v8@v8.7.2/internal/cmd/backstage.go:192 +0x4a0
github.com/snyk/vervet/v8/internal/cmd.UpdateCatalog(0x140001c1e80?)
	/Users/jatin/go/pkg/mod/github.com/snyk/vervet/v8@v8.7.2/internal/cmd/backstage.go:75 +0x24
github.com/urfave/cli/v2.(*Command).Run(0x1012c6ae0, 0x140001c1e80, {0x14000306c30, 0x1, 0x1})
	/Users/jatin/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:274 +0x5e0
github.com/urfave/cli/v2.(*Command).Run(0x1012c5e80, 0x140001c1dc0, {0x140001fdc80, 0x2, 0x2})
	/Users/jatin/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:267 +0x81c
github.com/urfave/cli/v2.(*Command).Run(0x14000248420, 0x140001c1c40, {0x1400018c330, 0x3, 0x3})
	/Users/jatin/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:267 +0x81c
github.com/urfave/cli/v2.(*App).RunContext(0x1012c8140, {0x100bced90, 0x140002edad0}, {0x1400018c330, 0x3, 0x3})
	/Users/jatin/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/app.go:332 +0x4f8
github.com/snyk/vervet/v8/internal/cmd.(*VervetApp).Run(0x14000181810, {0x1400018c330, 0x3, 0x3})
	/Users/jatin/go/pkg/mod/github.com/snyk/vervet/v8@v8.7.2/internal/cmd/cmd.go:51 +0xa0
main.main()
	/Users/jatin/go/pkg/mod/github.com/snyk/vervet/v8@v8.7.2/cmd/vervet/main.go:11 +0x3c
exit status 2
```