### PR TITLE
fix: openapi walker walks into additional properties

### DIFF
--- a/internal/openapiwalker/walker.go
+++ b/internal/openapiwalker/walker.go
@@ -250,6 +250,14 @@ func ProcessRefs(data any, p RefProcessor) error {
 		if err := ProcessRefs(v.Not, p); err != nil {
 			return err
 		}
+		if err := ProcessRefs(v.AdditionalProperties, p); err != nil {
+			return err
+		}
+
+	case openapi3.AdditionalProperties:
+		if err := ProcessRefs(v.Schema, p); err != nil {
+			return err
+		}
 
 	case *openapi3.PathItem:
 		if v != nil {

--- a/internal/openapiwalker/walker_test.go
+++ b/internal/openapiwalker/walker_test.go
@@ -290,6 +290,41 @@ func TestProcessRefs(t *testing.T) {
 			},
 		})
 	})
+
+	c.Run("processes schema refs inside additional properties", func(c *qt.C) {
+		doc := &openapi3.T{}
+		doc.Components = &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"key-1": {
+					Value: &openapi3.Schema{
+						AdditionalProperties: openapi3.AdditionalProperties{
+							Schema: &openapi3.SchemaRef{
+								Ref: "value-1",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		recorder := &recordRefProcessor{}
+		err := ProcessRefs(doc, recorder)
+		c.Assert(err, qt.IsNil)
+		c.Assert(toJson(c, recorder.SchemaRefs), qt.JSONEquals, []*openapi3.SchemaRef{
+			{
+				Value: &openapi3.Schema{
+					AdditionalProperties: openapi3.AdditionalProperties{
+						Schema: &openapi3.SchemaRef{
+							Ref: "value-1",
+						},
+					},
+				},
+			},
+			{
+				Ref: "value-1",
+			},
+		})
+	})
 }
 
 func toJson(c *qt.C, obj any) []byte {


### PR DESCRIPTION
- although we are enforcing additional properties `= false` going forward there are a few existing repos which use additional properties