### PR TITLE
fix: extra versions generated on pivot date

### DIFF
--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -161,7 +161,7 @@ func (c *Compiler) Build(apiName string, stopVersion vervet.Version) error {
 					version,
 				))
 			}
-			if version.Compare(stopVersion) >= 0 {
+			if version.Date.Compare(stopVersion.Date) >= 0 {
 				continue
 			}
 


### PR DESCRIPTION
- beta/experimentals should not be generated on or past the stop date