### PR TITLE
fix: use release context when preparing release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,7 @@ workflows:
 
       - prepare-release:
           name: Prepare Release
+          context: nodejs-app-release
           requires:
             - Test
             - Security Scans


### PR DESCRIPTION
The prepare release stage needs a github token to push tags, which was missing. That token exists on the nodejs-app-release context that we are using for the full release so reuse it.