### PR TITLE
feat: sanitize-command

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -83,6 +83,7 @@ var CLIApp = cli.App{
 		&LocalizeCommand,
 		&ResourceCommand,
 		&ResolveCommand,
+		&SanitizeCommand,
 	},
 }
 

--- a/internal/cmd/sanitize.go
+++ b/internal/cmd/sanitize.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/snyk/vervet/v8"
+	"github.com/snyk/vervet/v8/internal/storage"
+)
+
+var SanitizeCommand = cli.Command{
+	Name:      "sanitize",
+	Usage:     "Manually load compiled specs from subfolders, strip sensitive fields, write sanitized output",
+	ArgsUsage: " ",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "compiled-path",
+			Required: true,
+			Usage:    "Directory containing subfolders for each version, e.g. internal/rest/api/versions/",
+		},
+		&cli.StringFlag{
+			Name:     "out",
+			Usage:    "Output directory for sanitized versions",
+			Value:    "sanitized",
+			Required: false,
+		},
+		&cli.StringSliceFlag{
+			Name:  "exclude-extension",
+			Usage: "Regex patterns of extension names to remove (repeatable)",
+		},
+		&cli.StringSliceFlag{
+			Name:  "exclude-header",
+			Usage: "Regex patterns of header names to remove (repeatable)",
+		},
+		&cli.StringSliceFlag{
+			Name:  "exclude-path",
+			Usage: "Exact path(s) to remove from the final OpenAPI specs",
+		},
+	},
+	Action: sanitizeAction,
+}
+
+func sanitizeAction(c *cli.Context) error {
+	excludePatterns := vervet.ExcludePatterns{
+		ExtensionPatterns: c.StringSlice("exclude-extension"),
+		HeaderPatterns:    c.StringSlice("exclude-header"),
+		Paths:             c.StringSlice("exclude-path"),
+	}
+
+	compiledPath := c.String("compiled-path")
+
+	outDir := c.String("out")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create out directory %q: %w", outDir, err)
+	}
+
+	versionDirs, err := findVersionDirs(compiledPath)
+	if err != nil {
+		return fmt.Errorf("failed to find version subfolders in %q: %w", compiledPath, err)
+	}
+
+	if len(versionDirs) == 0 {
+		fmt.Fprintf(c.App.Writer, "No version subfolders found in %q\n", compiledPath)
+		return nil
+	}
+
+	coll, err := storage.NewCollator(
+		storage.CollatorExcludePattern(excludePatterns),
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to create collator: %w", err)
+	}
+
+	// for each version folder, read openapi.yaml/spec.yaml, parse version, add to Collator
+	const serviceName = "api" // or any label you prefer
+	for _, dir := range versionDirs {
+		specFile := filepath.Join(dir, "spec.yaml")
+		if _, statErr := os.Stat(specFile); statErr != nil {
+			// No recognized spec found, skip this version folder
+			continue
+		}
+
+		blob, err := os.ReadFile(specFile)
+		if err != nil {
+			return fmt.Errorf("failed to read spec file %q: %w", specFile, err)
+		}
+
+		versionName := filepath.Base(dir)
+		v, err := vervet.ParseVersion(versionName)
+		if err != nil {
+			fmt.Fprintf(c.App.Writer, "Skipping folder %q: not a valid version: %v\n", dir, err)
+			continue
+		}
+
+		digest := storage.NewDigest(blob)
+		rev := storage.ContentRevision{
+			Service: serviceName,
+			Version: v,
+			Digest:  digest,
+			Blob:    blob,
+		}
+		coll.Add(serviceName, rev)
+	}
+
+	sanitized, err := coll.Collate()
+	if err != nil {
+		return fmt.Errorf("collate failed: %w", err)
+	}
+
+	for version, doc := range sanitized {
+		versionOutDir := filepath.Join(outDir, version.String())
+		if err := os.MkdirAll(versionOutDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create version output dir %q: %w", versionOutDir, err)
+		}
+		outPath := filepath.Join(versionOutDir, "openapi.yaml")
+
+		jsonBytes, err := doc.MarshalJSON()
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON for version %s: %w", version, err)
+		}
+
+		// Write the final sanitized file
+		if err := os.WriteFile(outPath, jsonBytes, 0o644); err != nil {
+			return fmt.Errorf("failed to write sanitized spec %q: %w", outPath, err)
+		}
+	}
+
+	fmt.Fprintf(c.App.Writer, "Wrote sanitized specs to %s\n", outDir)
+	return nil
+}
+
+// findVersionDirs enumerates subdirectories of compiledPath and returns them sorted.
+func findVersionDirs(compiledPath string) ([]string, error) {
+	entries, err := os.ReadDir(compiledPath)
+	if err != nil {
+		return nil, err
+	}
+	var dirs []string
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs = append(dirs, filepath.Join(compiledPath, e.Name()))
+		}
+	}
+	sort.Strings(dirs)
+	return dirs, nil
+}

--- a/internal/cmd/sanitize_test.go
+++ b/internal/cmd/sanitize_test.go
@@ -1,0 +1,138 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/getkin/kin-openapi/openapi3"
+	"gopkg.in/yaml.v3"
+
+	"github.com/snyk/vervet/v8"
+	"github.com/snyk/vervet/v8/internal/cmd"
+)
+
+func TestSanitize(t *testing.T) {
+	c := qt.New(t)
+
+	// Create temp directories for source and output
+	srcDir := c.TempDir()
+	outDir := c.TempDir()
+
+	// Create test OpenAPI specs with sensitive data
+	tests := []struct {
+		version string
+		spec    *openapi3.T
+	}{
+		{
+			version: "2024-01-15",
+			spec: &openapi3.T{
+				OpenAPI: "3.0.0",
+				Info: &openapi3.Info{
+					Title:   "Test API",
+					Version: "1.0.0",
+				},
+				Paths: func() *openapi3.Paths {
+					paths := &openapi3.Paths{}
+					paths.Set("/public", &openapi3.PathItem{
+						Get: &openapi3.Operation{
+							OperationID: "getPublic",
+							Extensions: map[string]interface{}{
+								"x-internal-op": "should-be-removed",
+								"x-public-op":   "should-remain",
+							},
+							Parameters: []*openapi3.ParameterRef{
+								{
+									Value: &openapi3.Parameter{
+										Name:        "X-Internal-Header",
+										In:          "header",
+										Description: "Should be removed",
+									},
+								},
+								{
+									Value: &openapi3.Parameter{
+										Name:        "X-Public-Header",
+										In:          "header",
+										Description: "Should remain",
+									},
+								},
+							},
+						},
+					})
+					paths.Set("/internal", &openapi3.PathItem{
+						Get: &openapi3.Operation{
+							OperationID: "getInternal",
+						},
+					})
+					return paths
+				}(),
+			},
+		},
+	}
+
+	// Write test specs to source directory
+	for _, test := range tests {
+		versionDir := filepath.Join(srcDir, test.version)
+		err := os.MkdirAll(versionDir, 0755)
+		c.Assert(err, qt.IsNil)
+
+		specBytes, err := yaml.Marshal(test.spec)
+		c.Assert(err, qt.IsNil)
+
+		err = os.WriteFile(filepath.Join(versionDir, "spec.yaml"), specBytes, 0644)
+		c.Assert(err, qt.IsNil)
+	}
+
+	// Run sanitize command
+	err := cmd.Vervet.Run([]string{
+		"vervet",
+		"sanitize",
+		"--compiled-path", srcDir,
+		"--out", outDir,
+		"--exclude-extension", "^x-internal-.*$",
+		"--exclude-header", "^X-Internal-.*$",
+		"--exclude-path", "/internal",
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Verify output
+	for _, test := range tests {
+		c.Run("sanitized version "+test.version, func(c *qt.C) {
+			outPath := filepath.Join(outDir, test.version, "openapi.yaml")
+			doc, err := vervet.NewDocumentFile(outPath)
+			c.Assert(err, qt.IsNil)
+
+			// Check that internal path was removed
+			internalPath := doc.Paths.Find("/internal")
+			c.Assert(internalPath, qt.IsNil, qt.Commentf("Internal path should be removed"))
+
+			// Check that public path and its proper operations remain
+			publicPath := doc.Paths.Find("/public")
+			c.Assert(publicPath, qt.Not(qt.IsNil), qt.Commentf("Public path should remain"))
+			c.Assert(publicPath.Get, qt.Not(qt.IsNil))
+
+			// Check operation extensions
+			_, hasInternalOpExt := publicPath.Get.Extensions["x-internal-op"]
+			c.Assert(hasInternalOpExt, qt.IsFalse, qt.Commentf("Internal operation extension should be removed"))
+
+			_, hasPublicOpExt := publicPath.Get.Extensions["x-public-op"]
+			c.Assert(hasPublicOpExt, qt.IsTrue, qt.Commentf("Public operation extension should remain"))
+
+			// Check headers in parameters
+			var foundInternalHeader, foundPublicHeader bool
+			for _, param := range publicPath.Get.Parameters {
+				if param.Value.In == "header" {
+					if param.Value.Name == "X-Internal-Header" {
+						foundInternalHeader = true
+					}
+					if param.Value.Name == "X-Public-Header" {
+						foundPublicHeader = true
+					}
+				}
+			}
+			c.Assert(foundInternalHeader, qt.IsFalse, qt.Commentf("Internal header parameter should be removed"))
+			c.Assert(foundPublicHeader, qt.IsTrue, qt.Commentf("Public header parameter should remain"))
+		})
+	}
+}

--- a/internal/storage/disk/disk.go
+++ b/internal/storage/disk/disk.go
@@ -30,8 +30,8 @@ type Storage struct {
 type Option func(*Storage)
 
 type objectMeta struct {
-	blob    []byte
-	lastMod time.Time
+	Blob    []byte
+	LastMod time.Time
 }
 
 func New(path string, options ...Option) storage.Storage {
@@ -88,7 +88,7 @@ func (s *Storage) CollateVersions(ctx context.Context, serviceFilter map[string]
 
 	// all specs are stored as: "service-versions/{service_name}/{version}/{digest}.json"
 	for _, revKey := range serviceRevisions {
-		service, version, digest, err := parseServiceVersionRevisionKey(revKey)
+		service, version, digest, err := ParseServiceVersionRevisionKey(revKey)
 		if err != nil {
 			return err
 		}
@@ -109,9 +109,9 @@ func (s *Storage) CollateVersions(ctx context.Context, serviceFilter map[string]
 		revision := storage.ContentRevision{
 			Service:   service,
 			Version:   parsedVersion,
-			Timestamp: rev.lastMod,
+			Timestamp: rev.LastMod,
 			Digest:    storage.Digest(digest),
-			Blob:      rev.blob,
+			Blob:      rev.Blob,
 		}
 		aggregate.Add(service, revision)
 	}
@@ -179,7 +179,7 @@ func (s *Storage) VersionIndex(ctx context.Context) (vervet.VersionIndex, error)
 	}
 	vs := make(vervet.VersionSlice, len(objects))
 	for idx, obj := range objects {
-		_, versionStr, _, err := parseServiceVersionRevisionKey(obj)
+		_, versionStr, _, err := ParseServiceVersionRevisionKey(obj)
 		if err != nil {
 			return vervet.VersionIndex{}, err
 		}
@@ -269,7 +269,7 @@ func (s *Storage) ListObjects(ctx context.Context, key string) ([]string, error)
 	return objects, err
 }
 
-func parseServiceVersionRevisionKey(key string) (string, string, string, error) {
+func ParseServiceVersionRevisionKey(key string) (string, string, string, error) {
 	digestB64 := filepath.Base(key)
 	digestB64 = strings.TrimSuffix(digestB64, ".json")
 	digest, err := base64.StdEncoding.DecodeString(digestB64)
@@ -292,8 +292,8 @@ func (s *Storage) GetObjectWithMetadata(key string) (*objectMeta, error) {
 	lastMod := info.ModTime()
 	body, err := os.ReadFile(key)
 	return &objectMeta{
-		lastMod: lastMod,
-		blob:    body,
+		LastMod: lastMod,
+		Blob:    body,
 	}, err
 }
 


### PR DESCRIPTION
This PR introduces a new sanitize command to remove sensitive information from versioned OpenAPI specs before distribution. 

Given a directory of compiled specs (one subfolder per version), the command loads each spec.yaml, filters out configurable extensions, headers, or entire paths, and saves the sanitized spec to a specified output directory.

```
vervet sanitize \
  --compiled-path ./internal/rest/api/versions \
  --out ./sanitized \
  --exclude-extension '^x-internal$' \
  --exclude-header '^X-Secret$' \
  --exclude-path '/internal'
```

This will read all spec.yaml files under each version subfolder, remove fields matching the exclusion criteria, and write sanitized openapi.yaml files to the ./sanitized directory.
