### PR TITLE
fix: remove top level extensions

### DIFF
--- a/remove_elements.go
+++ b/remove_elements.go
@@ -63,6 +63,8 @@ func RemoveElements(doc *openapi3.T, excludes ExcludePatterns) error {
 }
 
 func (ex *excluder) apply() error {
+	// Remove top-level extensions
+	ex.applyExtensions(ex.doc.Extensions)
 	for _, pathItem := range ex.doc.Paths.Map() {
 		ex.applyExtensions(pathItem.Extensions)
 		for _, operation := range pathItem.Operations() {


### PR DESCRIPTION
We previously had a bug where top level extensions would still appear in the final compiled specs on the top level of the document.

This change attempts to fix that by applying the remove rules to the documents top level extensions