### PR TITLE
Fix/outputs from multi paths

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -52,7 +52,7 @@ servers:
     description: Test API`[1:],
 				}},
 				Output: &config.Output{
-					Path: "testdata/output",
+					Paths: []string{"testdata/output"},
 				},
 			},
 		},
@@ -90,7 +90,9 @@ apis:
         - /another/place
         - /and/another
 `[1:],
-		err: `output should specify one of 'path' or 'paths', not both \(apis\.testapi\.output\)`,
+		err: "failed to unmarshal project configuration: " +
+			"error unmarshaling JSON: " +
+			"output should specify one of 'path' or 'paths', not both",
 	}, {
 		err: `no apis defined`,
 	}}

--- a/config/project.go
+++ b/config/project.go
@@ -45,7 +45,7 @@ func (p *Project) validate() error {
 	if err != nil {
 		return err
 	}
-	err = p.APIs.init(p)
+	err = p.APIs.init()
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/backstage.go
+++ b/internal/cmd/backstage.go
@@ -190,7 +190,7 @@ func processCatalog(ctx *cli.Context, w io.Writer) error {
 	sort.Strings(apiNames)
 	for _, apiName := range apiNames {
 		apiConf := proj.APIs[apiName]
-		outputPaths := apiConf.Output.ResolvePaths()
+		outputPaths := apiConf.Output.Paths
 		if len(outputPaths) == 0 {
 			log.Printf("API %q has no output paths, this command will have no effect", apiName)
 			continue

--- a/internal/cmd/compiler.go
+++ b/internal/cmd/compiler.go
@@ -151,7 +151,7 @@ func projectFromContext(ctx *cli.Context) (*config.Project, error) {
 			Path: ctx.Args().Get(0),
 		}},
 		Output: &config.Output{
-			Path: ctx.Args().Get(1),
+			Paths: []string{ctx.Args().Get(1)},
 		},
 	}
 	if includePath := ctx.String("include"); includePath != "" {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -102,9 +102,6 @@ func New(ctx context.Context, proj *config.Project, options ...CompilerOption) (
 		// Build output
 		if apiConfig.Output != nil {
 			paths := apiConfig.Output.Paths
-			if len(paths) == 0 && apiConfig.Output.Path != "" {
-				paths = []string{apiConfig.Output.Path}
-			}
 			if len(paths) > 0 {
 				a.output = &output{
 					paths: paths,

--- a/internal/simplebuild/build_test.go
+++ b/internal/simplebuild/build_test.go
@@ -857,7 +857,7 @@ func TestBuildSkipsVersionCheckWhenFetchFails(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	dummyOutput := &config.Output{
-		Path: tempDir,
+		Paths: []string{tempDir},
 	}
 	dummyAPI := &config.API{
 		Name:      "dummy-api",

--- a/internal/simplebuild/output.go
+++ b/internal/simplebuild/output.go
@@ -27,7 +27,7 @@ type DocWriter struct {
 // NewWriter initialises any output paths, removing existing files and
 // directories if they are present.
 func NewWriter(cfg config.Output, appendOutputFiles bool) (*DocWriter, error) {
-	paths := getOutputPaths(cfg)
+	paths := cfg.Paths
 	toClear := paths
 	if appendOutputFiles {
 		// We treat the first path as the source of truth and copy the whole
@@ -126,22 +126,6 @@ func (out *DocWriter) Finalize() error {
 		}
 	}
 	return nil
-}
-
-// Some services have a need to write specs to multiple destinations. This
-// tends to happen in Typescript services in which we want to write specs to
-// two places:
-//   - src/** for committing into git and ingesting into Backstage
-//   - dist/** for runtime module access to compiled specs.
-//
-// To maintain backwards compatibility we still allow a single path in the
-// config file then normalise that here to an array.
-func getOutputPaths(cfg config.Output) []string {
-	paths := cfg.Paths
-	if len(paths) == 0 && cfg.Path != "" {
-		paths = []string{cfg.Path}
-	}
-	return paths
 }
 
 func getExisingSpecFiles(dir string) ([]string, error) {

--- a/internal/simplebuild/output_test.go
+++ b/internal/simplebuild/output_test.go
@@ -36,7 +36,7 @@ func TestDocSet_WriteOutputs(t *testing.T) {
 			name: "write the doc sets to outputs",
 			args: args{
 				cfg: config.Output{
-					Path: t.TempDir(),
+					Paths: []string{t.TempDir()},
 				},
 			},
 			docs: DocSet{
@@ -47,10 +47,10 @@ func TestDocSet_WriteOutputs(t *testing.T) {
 			},
 			assert: func(t *testing.T, args args) {
 				t.Helper()
-				files, err := filepath.Glob(filepath.Join(args.cfg.Path, "*"))
+				files, err := filepath.Glob(filepath.Join(args.cfg.Paths[0], "*"))
 				c.Assert(err, qt.IsNil)
 				c.Assert(files, qt.HasLen, 2)
-				goEmbedContents, err := os.ReadFile(path.Join(args.cfg.Path, "embed.go"))
+				goEmbedContents, err := os.ReadFile(path.Join(args.cfg.Paths[0], "embed.go"))
 				c.Assert(err, qt.IsNil)
 				c.Assert(string(goEmbedContents), qt.Contains, "2024-01-01")
 			},
@@ -59,7 +59,7 @@ func TestDocSet_WriteOutputs(t *testing.T) {
 			name: "clears dir if appendOutputFiles is false",
 			args: args{
 				cfg: config.Output{
-					Path: t.TempDir(),
+					Paths: []string{t.TempDir()},
 				},
 				appendOutputFiles: false,
 			},
@@ -71,15 +71,15 @@ func TestDocSet_WriteOutputs(t *testing.T) {
 			},
 			setup: func(t *testing.T, args args) {
 				t.Helper()
-				err = os.WriteFile(path.Join(args.cfg.Path, "existing-file"), []byte("existing"), 0644)
+				err = os.WriteFile(path.Join(args.cfg.Paths[0], "existing-file"), []byte("existing"), 0644)
 				c.Assert(err, qt.IsNil)
 			},
 			assert: func(t *testing.T, args args) {
 				t.Helper()
-				files, err := filepath.Glob(filepath.Join(args.cfg.Path, "*"))
+				files, err := filepath.Glob(filepath.Join(args.cfg.Paths[0], "*"))
 				c.Assert(err, qt.IsNil)
 				c.Assert(files, qt.HasLen, 2)
-				goEmbedContents, err := os.ReadFile(path.Join(args.cfg.Path, "embed.go"))
+				goEmbedContents, err := os.ReadFile(path.Join(args.cfg.Paths[0], "embed.go"))
 				c.Assert(err, qt.IsNil)
 				c.Assert(string(goEmbedContents), qt.Contains, "2024-01-01")
 			},
@@ -89,7 +89,7 @@ func TestDocSet_WriteOutputs(t *testing.T) {
 			name: "merges files if appendOutputFiles is true, embeds existing files",
 			args: args{
 				cfg: config.Output{
-					Path: t.TempDir(),
+					Paths: []string{t.TempDir()},
 				},
 				appendOutputFiles: true,
 			},
@@ -101,19 +101,19 @@ func TestDocSet_WriteOutputs(t *testing.T) {
 			},
 			setup: func(t *testing.T, args args) {
 				t.Helper()
-				err = os.WriteFile(path.Join(args.cfg.Path, "2024-02-01"), []byte("existing"), 0644)
+				err = os.WriteFile(path.Join(args.cfg.Paths[0], "2024-02-01"), []byte("existing"), 0644)
 				c.Assert(err, qt.IsNil)
-				err = os.WriteFile(path.Join(args.cfg.Path, "2024-02-02"), []byte("existing"), 0644)
+				err = os.WriteFile(path.Join(args.cfg.Paths[0], "2024-02-02"), []byte("existing"), 0644)
 				c.Assert(err, qt.IsNil)
-				err = os.WriteFile(path.Join(args.cfg.Path, "2024-02-03"), []byte("existing"), 0644)
+				err = os.WriteFile(path.Join(args.cfg.Paths[0], "2024-02-03"), []byte("existing"), 0644)
 				c.Assert(err, qt.IsNil)
 			},
 			assert: func(t *testing.T, args args) {
 				t.Helper()
-				files, err := filepath.Glob(filepath.Join(args.cfg.Path, "*"))
+				files, err := filepath.Glob(filepath.Join(args.cfg.Paths[0], "*"))
 				c.Assert(err, qt.IsNil)
 				c.Assert(files, qt.HasLen, 2+3)
-				goEmbedContents, err := os.ReadFile(path.Join(args.cfg.Path, "embed.go"))
+				goEmbedContents, err := os.ReadFile(path.Join(args.cfg.Paths[0], "embed.go"))
 				c.Assert(err, qt.IsNil)
 				c.Assert(string(goEmbedContents), qt.Contains, "2024-01-01")
 				c.Assert(string(goEmbedContents), qt.Contains, "2024-02-01")

--- a/specs/load.go
+++ b/specs/load.go
@@ -56,8 +56,14 @@ func GetOutputSpecs(ctx context.Context, api *config.API) ([]*vervet.Document, e
 // lazy operations.
 func GetOutputSpecsItr(ctx context.Context, api *config.API) iter.Seq2[*vervet.Document, error] {
 	return func(yield func(*vervet.Document, error) bool) {
+		path := api.Output.ResolvePaths()
+		if len(path) == 0 {
+			// No output defined for this api
+			return
+		}
 		resource := &config.ResourceSet{
-			Path: api.Output.Path,
+			// All output paths should have the same contents
+			Path: path[0],
 		}
 		paths, err := files.LocalFSSource{}.Match(resource)
 		if err != nil {

--- a/specs/load.go
+++ b/specs/load.go
@@ -56,14 +56,14 @@ func GetOutputSpecs(ctx context.Context, api *config.API) ([]*vervet.Document, e
 // lazy operations.
 func GetOutputSpecsItr(ctx context.Context, api *config.API) iter.Seq2[*vervet.Document, error] {
 	return func(yield func(*vervet.Document, error) bool) {
-		path := api.Output.ResolvePaths()
-		if len(path) == 0 {
+		outPaths := api.Output.Paths
+		if len(outPaths) == 0 {
 			// No output defined for this api
 			return
 		}
 		resource := &config.ResourceSet{
 			// All output paths should have the same contents
-			Path: path[0],
+			Path: outPaths[0],
 		}
 		paths, err := files.LocalFSSource{}.Match(resource)
 		if err != nil {


### PR DESCRIPTION
The vervet config allows both Path and Paths to be defined on the output.
GetOutputSpecs assumed that only the former was populated so wouldn't return specs if
only the latter was populated.

Having both Output.Path and Output.Paths was a source of errors waiting to
happen if the caller didn't call ResolvePaths first. This patch resolves the
paths when deserialising so it reduces the mental load overall.