### PR TITLE
feat: add Handler.WithErrorHandler to versionware

### DIFF
--- a/versionware/handler.go
+++ b/versionware/handler.go
@@ -108,3 +108,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set(HeaderSnykVersionServed, resolved.String())
 	handler.ServeHTTP(w, req)
 }
+
+// WithErrorHandler is a convenience wrapper around HandleErrors which
+// returns the handler. This is especially handy when chained with the
+// NewHandler function.
+func (h *Handler) WithErrorHandler(errFunc VersionErrorHandler) *Handler {
+	h.HandleErrors(errFunc)
+	return h
+}


### PR DESCRIPTION
This adds the method Handler.WithErrorHandler() so that passing in a custom error handling function can easily be done when constructing a new handler.

Consumers can thus easily pass in a JSON:API error handler:

```go
// Writes a JSON:API compatible error to w
func jsonapiErrHandler(w http.ResponseWriter, r *http.Request, status int, err error) {
    w.WriteHeader(status)
    w.Header().Set("Content-Encoding", "application/vnd.api+json")
    jsonapi.WriteError(w, jsonapi.NewError(status, err.Error()))
}

h = versionware.NewHandler(...).WithErrorHandler()
```